### PR TITLE
Removes func-name-mixedcase rule

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,6 +4,7 @@
     "rules": {
         "prettier/prettier": "error",
         "compiler-version": ["error", "^0.8.15"],
-        "func-visibility": ["warn", { "ignoreConstructors": true }]
+        "func-visibility": ["warn", { "ignoreConstructors": true }],
+        "func-name-mixedcase": false
     }
 }


### PR DESCRIPTION
Solhint is complaining about our `test_functionNames`. IMO, the underscore makes them a little more readable. 