### PR TITLE
Switching to /** */ style comments

### DIFF
--- a/.changeset/fuzzy-years-dress.md
+++ b/.changeset/fuzzy-years-dress.md
@@ -1,0 +1,5 @@
+---
+"sound-protocol": patch
+---
+
+Switching to /** */ style comments

--- a/contracts/SoundCreator/SoundCreatorV1.sol
+++ b/contracts/SoundCreator/SoundCreatorV1.sol
@@ -32,8 +32,10 @@ import "../SoundEdition/ISoundEditionV1.sol";
 import "chiru-labs/ERC721A-Upgradeable/ERC721AUpgradeable.sol";
 import "openzeppelin/proxy/Clones.sol";
 
-/// @title Sound Creator V1
-/// @dev Factory for deploying Sound edition contracts.
+/**
+ * @title Sound Creator V1
+ * @dev Factory for deploying Sound edition contracts.
+ */
 contract SoundCreatorV1 {
     /***********************************
                 STORAGE
@@ -51,7 +53,9 @@ contract SoundCreatorV1 {
         soundRegistry = _soundRegistry;
     }
 
-    /// @dev Deploys a Sound edition contract.
+    /**
+     * @dev Deploys a Sound edition contract.
+     */
     function createSound(
         string memory _name,
         string memory _symbol,

--- a/contracts/SoundEdition/ISoundEditionV1.sol
+++ b/contracts/SoundEdition/ISoundEditionV1.sol
@@ -33,16 +33,20 @@ import "../modules/Metadata/IMetadataModule.sol";
                ▓██████████████████████████████████████████████████████████                
 */
 
-/// @title ISoundEditionV1
-/// @author Sound.xyz
+/**
+ * @title ISoundEditionV1
+ * @author Sound.xyz
+ */
 interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
-    /// @dev Initializes the contract
-    /// @param owner Owner of contract (artist)
-    /// @param name Name of the token
-    /// @param symbol Symbol of the token
-    /// @param metadataModule Address of metadata module, address(0x00) if not used
-    /// @param baseURI Base URI
-    /// @param contractURI Contract URI for OpenSea storefront
+    /**
+     * @dev Initializes the contract
+     * @param owner Owner of contract (artist)
+     * @param name Name of the token
+     * @param symbol Symbol of the token
+     * @param metadataModule Address of metadata module, address(0x00) if not used
+     * @param baseURI Base URI
+     * @param contractURI Contract URI for OpenSea storefront
+     */
     function initialize(
         address owner,
         string memory name,
@@ -52,33 +56,45 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
         string memory contractURI
     ) external;
 
-    /// @dev Mints `quantity` tokens to addrress `to`
-    /// Each token will be assigned a token ID that is consecutively increasing.
-    /// The caller must have the `MINTERROLE`, which can be granted via
-    /// {grantRole}. Multiple minters, such as different minter contracts,
-    /// can be authorized simultaneously.
-    /// @param to Address to mint to
-    /// @param quantity Number of tokens to mint
+    /**
+     * @dev Mints `quantity` tokens to addrress `to`
+     * Each token will be assigned a token ID that is consecutively increasing.
+     * The caller must have the `MINTERROLE`, which can be granted via
+     * {grantRole}. Multiple minters, such as different minter contracts,
+     * can be authorized simultaneously.
+     * @param to Address to mint to
+     * @param quantity Number of tokens to mint
+     */
     function mint(address to, uint256 quantity) external payable;
 
-    /// @dev Informs other contracts which interfaces this contract supports.
-    /// https://eips.ethereum.org/EIPS/eip-165
-    /// @param interfaceId The interface id to check.
+    /**
+     * @dev Informs other contracts which interfaces this contract supports.
+     * https://eips.ethereum.org/EIPS/eip-165
+     * @param interfaceId The interface id to check.
+     */
     function supportsInterface(bytes4 interfaceId)
         external
         view
         override(IERC721AUpgradeable, IERC165Upgradeable)
         returns (bool);
 
-    /// @dev Sets metadata module
+    /**
+     *  @dev Sets metadata module
+     */
     function setMetadataModule(IMetadataModule metadataModule) external;
 
-    /// @dev Sets global base URI
+    /**
+     *  @dev Sets global base URI
+     */
     function setBaseURI(string memory baseURI) external;
 
-    /// @dev Sets contract URI
+    /**
+     *   @dev Sets contract URI
+     */
     function setContractURI(string memory _contractURI) external;
 
-    /// @dev Freezes metadata by preventing any more changes to base URI
+    /**
+     *   @dev Freezes metadata by preventing any more changes to base URI
+     */
     function freezeMetadata() external;
 }

--- a/contracts/SoundEdition/SoundEditionV1.sol
+++ b/contracts/SoundEdition/SoundEditionV1.sol
@@ -34,8 +34,10 @@ import "openzeppelin-upgradeable/access/AccessControlUpgradeable.sol";
                ▓██████████████████████████████████████████████████████████                
 */
 
-/// @title SoundEditionV1
-/// @author Sound.xyz
+/**
+ * @title SoundEditionV1
+ * @author Sound.xyz
+ */
 contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, OwnableUpgradeable, AccessControlUpgradeable {
     // ================================
     // CONSTANTS

--- a/contracts/modules/Metadata/IMetadataModule.sol
+++ b/contracts/modules/Metadata/IMetadataModule.sol
@@ -28,9 +28,10 @@ pragma solidity ^0.8.15;
                ▓██████████████████████████████████████████████████████████                
 */
 
-/// @title IMetadataModule
-/// @author Sound.xyz
-
+/**
+ * @title IMetadataModule
+ * @author Sound.xyz
+ */
 interface IMetadataModule {
     function tokenURI(uint256 tokenId) external view returns (string memory);
 }

--- a/contracts/modules/Minters/FixedPricePermissionedSaleMinter.sol
+++ b/contracts/modules/Minters/FixedPricePermissionedSaleMinter.sol
@@ -6,16 +6,16 @@ import "./MintControllerBase.sol";
 import "../../SoundEdition/ISoundEditionV1.sol";
 import "solady/utils/ECDSA.sol";
 
-/// @title Fixed Price Permissioned Sale Minter
-/// @dev Minter class for sales approved with signatures.
+/**
+ * @title Fixed Price Permissioned Sale Minter
+ * @dev Minter class for sales approved with signatures.
+ */
 contract FixedPricePermissionedSaleMinter is MintControllerBase {
     using ECDSA for bytes32;
 
-    // ERRORS
     error WrongEtherValue();
     error SoldOut();
     error InvalidSignature();
-
     error SignerIsZeroAddress();
 
     // prettier-ignore
@@ -39,7 +39,9 @@ contract FixedPricePermissionedSaleMinter is MintControllerBase {
 
     mapping(address => EditionMintData) internal _editionMintData;
 
-    /// @dev Initializes the configuration for an edition mint.
+    /**
+     * @dev Initializes the configuration for an edition mint.
+     */
     function createEditionMint(
         address edition,
         uint256 price,
@@ -62,17 +64,25 @@ contract FixedPricePermissionedSaleMinter is MintControllerBase {
         );
     }
 
+    /**
+     * @dev Returns the given edition's mint configuration.
+     * @param edition The edition to get the mint configuration for.
+     */
     function editionMintData(address edition) public view returns (EditionMintData memory) {
         return _editionMintData[edition];
     }
 
-    /// @dev Deletes the configuration for an edition mint.
+    /**
+     * @dev Deletes the configuration for an edition mint.
+     */
     function deleteEditionMint(address edition) public {
         _deleteEditionMintController(edition);
         delete _editionMintData[edition];
     }
 
-    /// @dev Mints tokens for a given edition.
+    /**
+     * @dev Mints tokens for a given edition.
+     */
     function mint(
         address edition,
         uint32 quantity,

--- a/contracts/modules/Minters/FixedPricePublicSaleMinter.sol
+++ b/contracts/modules/Minters/FixedPricePublicSaleMinter.sol
@@ -5,10 +5,11 @@ pragma solidity ^0.8.15;
 import "./MintControllerBase.sol";
 import "../../SoundEdition/ISoundEditionV1.sol";
 
-/// @title Fixed Price Public Sale Minter
-/// @dev Minter class for sales at a fixed price within a time range.
+/**
+ * @title Fixed Price Public Sale Minter
+ * @dev Minter class for sales at a fixed price within a time range.
+ */
 contract FixedPricePublicSaleMinter is MintControllerBase {
-    // ERRORS
     error WrongEtherValue();
     error SoldOut();
     error MintNotStarted();
@@ -43,13 +44,15 @@ contract FixedPricePublicSaleMinter is MintControllerBase {
 
     mapping(address => EditionMintData) internal _editionMintData;
 
-    /// @dev Initializes the configuration for an edition mint.
-    /// @param edition Address of the song edition contract we are minting for.
-    /// @param price Sale price in ETH for minting a single token in `edition`.
-    /// @param startTime Start timestamp of sale (in seconds since unix epoch).
-    /// @param endTime End timestamp of sale (in seconds since unix epoch).
-    /// @param maxMintable The maximum number of tokens that can can be minted for this sale.
-    /// @param maxAllowedPerWallet The maximum number of tokens that a wallet can mint.
+    /**
+     * @dev Initializes the configuration for an edition mint.
+     * @param edition Address of the song edition contract we are minting for.
+     * @param price Sale price in ETH for minting a single token in `edition`.
+     * @param startTime Start timestamp of sale (in seconds since unix epoch).
+     * @param endTime End timestamp of sale (in seconds since unix epoch).
+     * @param maxMintable The maximum number of tokens that can can be minted for this sale.
+     * @param maxAllowedPerWallet The maximum number of tokens that a wallet can mint.
+     */
     function createEditionMint(
         address edition,
         uint256 price,
@@ -76,25 +79,36 @@ contract FixedPricePublicSaleMinter is MintControllerBase {
         );
     }
 
+    /**
+     * @dev Deletes a given edition's mint configuration.
+     * @param edition The edition to delete the mint configuration for.
+     */
     function deleteEditionMint(address edition) public {
         _deleteEditionMintController(edition);
         delete _editionMintData[edition];
     }
 
+    /**
+     * @dev Returns the given edition's mint configuration.
+     * @param edition The edition to get the mint configuration for.
+     */
     function editionMintData(address edition) public view returns (EditionMintData memory) {
         return _editionMintData[edition];
     }
 
-    /// @dev Mints the required `quantity` in song `edition.
-    /// @param edition Address of the song edition contract we are minting for.
-    /// @param quantity Token quantity to mint in song `edition`.
+    /**
+     * @dev Mints the required `quantity` in song `edition.
+     * @param edition Address of the song edition contract we are minting for.
+     * @param quantity Token quantity to mint in song `edition`.
+     */
     function mint(address edition, uint32 quantity) public payable {
         EditionMintData storage data = _editionMintData[edition];
 
         uint256 userBalance = ISoundEditionV1(edition).balanceOf(msg.sender);
         // If the maximum allowed per wallet is set (i.e. is different to 0)
         // check the required additional quantity does not exceed the set maximum
-        if (data.maxAllowedPerWallet > 0 && ((userBalance + quantity) > data.maxAllowedPerWallet)) revert ExceedsMaxPerWallet();
+        if (data.maxAllowedPerWallet > 0 && ((userBalance + quantity) > data.maxAllowedPerWallet))
+            revert ExceedsMaxPerWallet();
 
         if ((data.totalMinted += quantity) > data.maxMintable) revert SoldOut();
         if (data.price * quantity != msg.value) revert WrongEtherValue();

--- a/contracts/modules/Minters/MintControllerBase.sol
+++ b/contracts/modules/Minters/MintControllerBase.sol
@@ -2,8 +2,10 @@
 
 pragma solidity ^0.8.15;
 
-/// @title Mint Controller Base
-/// @dev The `MintControllerBase` class maintains a central storage record of mint controllers.
+/**
+ * @title Mint Controller Base
+ * @dev The `MintControllerBase` class maintains a central storage record of mint controllers.
+ */
 abstract contract MintControllerBase {
     /// @dev The caller must be the the controller of this edition to perform this action.
     error MintControllerUnauthorized();
@@ -31,9 +33,11 @@ abstract contract MintControllerBase {
         _;
     }
 
-    /// @dev Assigns the current caller as the controller to `edition`.
-    /// Calling conditions:
-    /// - The `edition` must not have a controller.
+    /**
+     * @dev Assigns the current caller as the controller to `edition`.
+     * Calling conditions:
+     * - The `edition` must not have a controller.
+     */
     function _createEditionMintController(address edition) internal {
         if (!_callerIsEditionOwner(edition)) revert CallerNotEditionOwner();
         if (_controllers[edition] != address(0)) revert MintControllerAlreadyExists(_controllers[edition]);
@@ -41,7 +45,9 @@ abstract contract MintControllerBase {
         emit MintControllerUpdated(edition, msg.sender);
     }
 
-    /// @dev Returns whether the caller is the owner of `edition`.
+    /**
+     * @dev Returns whether the caller is the owner of `edition`.
+     */
     function _callerIsEditionOwner(address edition) private returns (bool result) {
         // To avoid defining an interface just to call `owner()`.
         // And Solidity does not have try catch for plain old `call`.
@@ -70,20 +76,26 @@ abstract contract MintControllerBase {
         }
     }
 
-    /// @dev Convenience function for deleting a mint controller.
-    /// Equivalent to `setEditionMintController(edition, address(0))`.
+    /**
+     * @dev Convenience function for deleting a mint controller.
+     * Equivalent to `setEditionMintController(edition, address(0))`.
+     */
     function _deleteEditionMintController(address edition) internal {
         setEditionMintController(edition, address(0));
     }
 
-    /// @dev Returns the mint controller for `edition`.
+    /**
+     * @dev Returns the mint controller for `edition`.
+     */
     function editionMintController(address edition) public view returns (address) {
         return _controllers[edition];
     }
 
-    /// @dev Sets the new `controller` for `edition`.
-    /// Calling conditions:
-    /// - The caller must be the current controller for `edition`.
+    /**
+     * @dev Sets the new `controller` for `edition`.
+     * Calling conditions:
+     * - The caller must be the current controller for `edition`.
+     */
     function setEditionMintController(address edition, address controller)
         public
         virtual


### PR DESCRIPTION
Following up on @apoorvlathey's [suggestion](https://soundxyz.slack.com/archives/C03KRFU07LL/p1659594708965859). I didn't change comments above errors or events since they aren't using multiple lines, but I think we should always do it for functions unless they're using `@inheritdoc ...`.