### PR TITLE
Removes pinned foundry version from gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-63ed1099a74fded7c3a7182b5a508bd7d16743d3
+          version: nightly
 
       - name: Run Forge build
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly-63ed1099a74fded7c3a7182b5a508bd7d16743d3
+          version: nightly
           
       - uses: pnpm/action-setup@v2.0.1
         with:


### PR DESCRIPTION
The pinned version is now failing: https://github.com/soundxyz/sound-protocol/runs/7795255624?check_suite_focus=true

Removing it makes CI work again. 🤷 