### PR TITLE
Populates METADATA_MODULE address for gas benchmarking

### DIFF
--- a/.changeset/shy-monkeys-wash.md
+++ b/.changeset/shy-monkeys-wash.md
@@ -1,0 +1,5 @@
+---
+"sound-protocol": minor
+---
+
+Populates METADATA_MODULE address for gas benchmarking & adjusts tests as needed

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,4 @@
 [submodule "lib/murky"]
 	path = lib/murky
 	url = https://github.com/dmfxyz/murky
+	ignore = dirty

--- a/tests/SoundEdition/metadata.t.sol
+++ b/tests/SoundEdition/metadata.t.sol
@@ -31,8 +31,11 @@ contract SoundEdition_metadata is TestConfig {
         );
     }
 
-    function _createEditionWithMetadata() internal returns (MockSoundEditionV1 soundEdition) {
-        MockMetadataModule metadataModule = new MockMetadataModule();
+    function _createEditionWithMetadata()
+        internal
+        returns (MockSoundEditionV1 soundEdition, MockMetadataModule metadataModule)
+    {
+        metadataModule = new MockMetadataModule();
 
         // deploy new sound contract
         soundEdition = MockSoundEditionV1(
@@ -70,7 +73,7 @@ contract SoundEdition_metadata is TestConfig {
 
     // Generate tokenURI using the metadata module
     function test_metadataModule() public {
-        MockSoundEditionV1 soundEdition = _createEditionWithMetadata();
+        (MockSoundEditionV1 soundEdition, ) = _createEditionWithMetadata();
 
         // mint NFTs
         soundEdition.mint(2);
@@ -278,10 +281,10 @@ contract SoundEdition_metadata is TestConfig {
     }
 
     function test_freezeMetadataEmitsEvent() public {
-        MockSoundEditionV1 soundEdition = _createEdition();
+        (MockSoundEditionV1 soundEdition, IMetadataModule metadataModule) = _createEditionWithMetadata();
 
         vm.expectEmit(false, false, false, true);
-        emit MetadataFrozen(METADATA_MODULE, BASE_URI, CONTRACT_URI);
+        emit MetadataFrozen(metadataModule, BASE_URI, CONTRACT_URI);
         soundEdition.freezeMetadata();
     }
 }

--- a/tests/TestConfig.sol
+++ b/tests/TestConfig.sol
@@ -12,7 +12,7 @@ contract TestConfig is Test {
     // Artist contract creation vars
     string constant SONG_NAME = "Never Gonna Give You Up";
     string constant SONG_SYMBOL = "NEVER";
-    IMetadataModule constant METADATA_MODULE = IMetadataModule(address(0));
+    IMetadataModule constant METADATA_MODULE = IMetadataModule(address(390720730));
     string constant BASE_URI = "https://example.com/metadata/";
     string constant CONTRACT_URI = "https://example.com/storefront/";
     uint32 constant MASTER_MAX_MINTABLE = type(uint32).max;


### PR DESCRIPTION
If the `METADATA_MODULE` is null, it makes `createSound` cheaper. Given it will be set for most editions, it should have a value for better gas estimates.