### PR TITLE
Adds SoundEdition getMembersOfRole

### DIFF
--- a/.changeset/swift-dodos-fly.md
+++ b/.changeset/swift-dodos-fly.md
@@ -1,0 +1,5 @@
+---
+"sound-protocol": minor
+---
+
+Adds SoundEditionV1.getMembersOfRole

--- a/contracts/SoundEdition/ISoundEditionV1.sol
+++ b/contracts/SoundEdition/ISoundEditionV1.sol
@@ -136,4 +136,6 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
     function randomnessLockedTimestamp() external view returns (uint32);
 
     function mintRandomness() external view returns (bytes32);
+
+    function getMembersOfRole(bytes32 role) external view returns (address[] memory);
 }

--- a/contracts/SoundEdition/SoundEditionV1.sol
+++ b/contracts/SoundEdition/SoundEditionV1.sol
@@ -7,7 +7,7 @@ import "chiru-labs/ERC721A-Upgradeable/extensions/ERC721ABurnableUpgradeable.sol
 import "openzeppelin-upgradeable/access/OwnableUpgradeable.sol";
 import "./ISoundEditionV1.sol";
 import "../modules/Metadata/IMetadataModule.sol";
-import "openzeppelin-upgradeable/access/AccessControlUpgradeable.sol";
+import "openzeppelin-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
 
 /*
                  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
@@ -44,7 +44,7 @@ contract SoundEditionV1 is
     ERC721AQueryableUpgradeable,
     ERC721ABurnableUpgradeable,
     OwnableUpgradeable,
-    AccessControlUpgradeable
+    AccessControlEnumerableUpgradeable
 {
     // ================================
     // CONSTANTS
@@ -244,12 +244,12 @@ contract SoundEditionV1 is
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(ISoundEditionV1, ERC721AUpgradeable, IERC721AUpgradeable, AccessControlUpgradeable)
+        override(ISoundEditionV1, ERC721AUpgradeable, IERC721AUpgradeable, AccessControlEnumerableUpgradeable)
         returns (bool)
     {
         return
             ERC721AUpgradeable.supportsInterface(interfaceId) ||
-            AccessControlUpgradeable.supportsInterface(interfaceId);
+            AccessControlEnumerableUpgradeable.supportsInterface(interfaceId);
     }
 
     /// @inheritdoc IERC2981Upgradeable
@@ -265,5 +265,16 @@ contract SoundEditionV1 is
     /// @inheritdoc ERC721AUpgradeable
     function _startTokenId() internal pure override returns (uint256) {
         return 1;
+    }
+
+    /// @inheritdoc ISoundEditionV1
+    function getMembersOfRole(bytes32 role) external view returns (address[] memory members) {
+        uint256 count = getRoleMemberCount(role);
+
+        members = new address[](count);
+
+        for (uint256 i = 0; i < count; i++) {
+            members[i] = getRoleMember(role, i);
+        }
     }
 }

--- a/tests/SoundEdition/misc.t.sol
+++ b/tests/SoundEdition/misc.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.16;
+
+import "../TestConfig.sol";
+import "../../contracts/SoundEdition/ISoundEditionV1.sol";
+import "openzeppelin-upgradeable/access/IAccessControlEnumerableUpgradeable.sol";
+
+/**
+ * @dev Miscellaneous tests for SoundEdition
+ */
+contract SoundEdition_misc is TestConfig {
+    function test_getMembersOfRole() public {
+        ISoundEditionV1 edition = createGenericEdition();
+
+        // Test with 4 minters
+
+        address[] memory minters = new address[](4);
+        minters[0] = address(111);
+        minters[1] = address(222);
+        minters[2] = address(333);
+        minters[3] = address(444);
+
+        for (uint256 i = 0; i < minters.length; i++) {
+            IAccessControlEnumerableUpgradeable(address(edition)).grantRole(edition.MINTER_ROLE(), minters[i]);
+        }
+
+        address[] memory expectedMinters = edition.getMembersOfRole(edition.MINTER_ROLE());
+
+        for (uint256 i = 0; i < minters.length; i++) {
+            assertEq(expectedMinters[i], minters[i]);
+        }
+
+        // Test with 5 admins
+
+        address[] memory admins = new address[](5);
+        admins[0] = address(555);
+        admins[1] = address(666);
+        admins[2] = address(777);
+        admins[3] = address(888);
+        admins[4] = address(999);
+
+        for (uint256 i = 0; i < admins.length; i++) {
+            IAccessControlEnumerableUpgradeable(address(edition)).grantRole(edition.ADMIN_ROLE(), admins[i]);
+        }
+
+        address[] memory expectedAdmins = edition.getMembersOfRole(edition.ADMIN_ROLE());
+
+        for (uint256 i = 0; i < admins.length; i++) {
+            assertEq(expectedAdmins[i], admins[i]);
+        }
+    }
+}


### PR DESCRIPTION
Adds `getMembersOfRole` view function. The main reason for adding this is so we can use it in the SDK to retrieve all the minters registered for an edition. 

It required swapping `AccessControlUpgradeable` with `AccessControlEnumerableUpgradeable`