### PR TITLE
Change price from uint256 to uint96

### DIFF
--- a/contracts/modules/FixedPriceSignatureMinter.sol
+++ b/contracts/modules/FixedPriceSignatureMinter.sol
@@ -23,7 +23,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
     /// @inheritdoc IFixedPriceSignatureMinter
     function createEditionMint(
         address edition,
-        uint256 price_,
+        uint96 price_,
         address signer,
         uint32 maxMintable_,
         uint32 startTime,

--- a/contracts/modules/MerkleDropMinter.sol
+++ b/contracts/modules/MerkleDropMinter.sol
@@ -34,7 +34,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
     function createEditionMint(
         address edition,
         bytes32 merkleRootHash,
-        uint256 price_,
+        uint96 price_,
         uint32 startTime,
         uint32 endTime,
         uint32 maxMintable_,
@@ -107,7 +107,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
     }
 
     /**
-     * @dev Returns the `EditionMintData` for `edition.
+     * @dev Returns the `EditionMintData` for `edition`.
      * @param edition Address of the song edition contract we are minting for.
      */
     function editionMintData(address edition, uint256 mintId) public view returns (EditionMintData memory) {

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -48,7 +48,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     /// @inheritdoc IRangeEditionMinter
     function createEditionMint(
         address edition,
-        uint256 price_,
+        uint96 price_,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,
@@ -149,7 +149,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     // ================================
 
     /**
-     * @dev Returns the `EditionMintData` for `edition.
+     * @dev Returns the `EditionMintData` for `edition`.
      * @param edition Address of the song edition contract we are minting for.
      */
     function editionMintData(address edition, uint256 mintId) public view returns (EditionMintData memory) {

--- a/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
+++ b/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
@@ -8,7 +8,7 @@ import { IMinterModule } from "@core/interfaces/IMinterModule.sol";
  */
 struct EditionMintData {
     // The price at which each token will be sold, in ETH.
-    uint256 price;
+    uint96 price;
     // Whitelist signer address.
     address signer;
     // The maximum number of tokens that can can be minted for this sale.
@@ -24,7 +24,7 @@ struct MintInfo {
     uint32 startTime;
     uint32 endTime;
     bool mintPaused;
-    uint256 price;
+    uint96 price;
     uint32 maxMintable;
     uint32 maxMintablePerAccount;
     uint32 totalMinted;
@@ -47,7 +47,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
     event FixedPriceSignatureMintCreated(
         address indexed edition,
         uint256 indexed mintId,
-        uint256 price,
+        uint96 price,
         address signer,
         uint32 maxMintable
     );
@@ -74,7 +74,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
      */
     function createEditionMint(
         address edition,
-        uint256 price_,
+        uint96 price_,
         address signer,
         uint32 maxMintable_,
         uint32 startTime,

--- a/contracts/modules/interfaces/IMerkleDropMinter.sol
+++ b/contracts/modules/interfaces/IMerkleDropMinter.sol
@@ -10,7 +10,7 @@ struct EditionMintData {
     // Hash of the root node for the merkle tree drop
     bytes32 merkleRootHash;
     // The price at which each token will be sold, in ETH.
-    uint256 price;
+    uint96 price;
     // The maximum number of tokens that can can be minted for this sale.
     uint32 maxMintable;
     // The maximum number of tokens that a wallet can mint.
@@ -26,7 +26,7 @@ struct MintInfo {
     uint32 startTime;
     uint32 endTime;
     bool mintPaused;
-    uint256 price;
+    uint96 price;
     uint32 maxMintable;
     uint32 maxMintablePerAccount;
     uint32 totalMinted;
@@ -54,7 +54,7 @@ interface IMerkleDropMinter is IMinterModule {
         address indexed edition,
         uint256 indexed mintId,
         bytes32 merkleRootHash,
-        uint256 price,
+        uint96 price,
         uint32 startTime,
         uint32 endTime,
         uint32 maxMintable,
@@ -92,7 +92,7 @@ interface IMerkleDropMinter is IMinterModule {
     function createEditionMint(
         address edition,
         bytes32 merkleRootHash,
-        uint256 price_,
+        uint96 price_,
         uint32 startTime,
         uint32 endTime,
         uint32 maxMintable_,

--- a/contracts/modules/interfaces/IRangeEditionMinter.sol
+++ b/contracts/modules/interfaces/IRangeEditionMinter.sol
@@ -8,7 +8,7 @@ import { IMinterModule } from "@core/interfaces/IMinterModule.sol";
  */
 struct EditionMintData {
     // The price at which each token will be sold, in ETH.
-    uint256 price;
+    uint96 price;
     // The timestamp (in seconds since unix epoch) after which the
     // max amount of tokens mintable will drop from
     // `maxMintableUpper` to `maxMintableLower`.
@@ -30,7 +30,7 @@ struct MintInfo {
     uint32 startTime;
     uint32 endTime;
     bool mintPaused;
-    uint256 price;
+    uint96 price;
     uint32 maxMintable;
     uint32 maxMintablePerAccount;
     uint32 totalMinted;
@@ -46,7 +46,7 @@ interface IRangeEditionMinter is IMinterModule {
     event RangeEditionMintCreated(
         address indexed edition,
         uint256 indexed mintId,
-        uint256 price,
+        uint96 price,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,
@@ -87,7 +87,7 @@ interface IRangeEditionMinter is IMinterModule {
      */
     function createEditionMint(
         address edition,
-        uint256 price_,
+        uint96 price_,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,

--- a/tests/mocks/MockMinter.sol
+++ b/tests/mocks/MockMinter.sol
@@ -23,7 +23,7 @@ contract MockMinter is BaseMinter {
         _mint(edition, mintId, quantity, affiliate);
     }
 
-    function setPrice(uint256 price_) external {
+    function setPrice(uint96 price_) external {
         _currentPrice = price_;
     }
 

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -113,7 +113,7 @@ contract MintControllerBaseTests is TestConfig {
 
         uint256 mintId = minter.createEditionMint(address(edition), START_TIME, END_TIME);
 
-        uint256 price = 1;
+        uint96 price = 1;
         minter.setPrice(price);
 
         vm.expectRevert(abi.encodeWithSelector(IMinterModule.WrongEtherValue.selector, price * 2 - 1, price * 2));
@@ -129,7 +129,7 @@ contract MintControllerBaseTests is TestConfig {
 
         minter.setEditionMintPaused(address(edition), mintId, true);
 
-        uint256 price = 1;
+        uint96 price = 1;
         minter.setPrice(price);
 
         vm.expectRevert(IMinterModule.MintPaused.selector);
@@ -231,7 +231,7 @@ contract MintControllerBaseTests is TestConfig {
         uint16 affiliateDiscountBPS = 10;
         uint16 affiliateFeeBPS = 10;
         uint16 platformFeeBPS = 10;
-        uint256 price = 1 ether;
+        uint96 price = 1 ether;
         uint32 quantity = 2;
 
         test_mintAndWithdrawlWithAffiliateAndPlatformFee(
@@ -287,7 +287,7 @@ contract MintControllerBaseTests is TestConfig {
         SoundEditionV1 edition = _createEdition(EDITION_MAX_MINTABLE);
         uint256 mintId = minter.createEditionMint(address(edition), START_TIME, END_TIME);
 
-        uint256 price = 1 ether;
+        uint96 price = 1 ether;
         minter.setPrice(price);
 
         affiliateFeeBPS = affiliateFeeBPS % minter.MAX_BPS();
@@ -314,7 +314,7 @@ contract MintControllerBaseTests is TestConfig {
         SoundEditionV1 edition = _createEdition(EDITION_MAX_MINTABLE);
         uint256 mintId = minter.createEditionMint(address(edition), START_TIME, END_TIME);
 
-        uint256 price = 1 ether;
+        uint96 price = 1 ether;
         minter.setPrice(price);
 
         platformFeeBPS = platformFeeBPS % minter.MAX_BPS();
@@ -344,7 +344,7 @@ contract MintControllerBaseTests is TestConfig {
         uint16 affiliateDiscountBPS,
         uint16 affiliateFeeBPS,
         uint16 platformFeeBPS,
-        uint256 price,
+        uint96 price,
         uint32 quantity
     ) public {
         price = price % 1e19;

--- a/tests/modules/FixedPriceSignatureMinter.t.sol
+++ b/tests/modules/FixedPriceSignatureMinter.t.sol
@@ -13,7 +13,7 @@ import { TestConfig } from "../TestConfig.sol";
 contract FixedPriceSignatureMinterTests is TestConfig {
     using ECDSA for bytes32;
 
-    uint256 constant PRICE = 1;
+    uint96 constant PRICE = 1;
     uint32 constant MAX_MINTABLE = 5;
     uint256 constant SIGNER_PRIVATE_KEY = 1;
     uint256 constant MINT_ID = 0;
@@ -24,7 +24,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     event FixedPriceSignatureMintCreated(
         address indexed edition,
         uint256 indexed mintId,
-        uint256 price,
+        uint96 price,
         address signer,
         uint32 maxMintable
     );

--- a/tests/modules/GoldenEggMetadata.t.sol
+++ b/tests/modules/GoldenEggMetadata.t.sol
@@ -10,7 +10,7 @@ import { ISoundEditionV1 } from "@core/interfaces/ISoundEditionV1.sol";
 import { TestConfig } from "../TestConfig.sol";
 
 contract GoldenEggMetadataTests is TestConfig {
-    uint256 constant PRICE = 1 ether;
+    uint96 constant PRICE = 1 ether;
 
     uint32 constant START_TIME = 100;
 

--- a/tests/modules/MintersIntegration.t.sol
+++ b/tests/modules/MintersIntegration.t.sol
@@ -16,17 +16,17 @@ contract MintersIntegration is TestConfig {
     uint32 public constant END_TIME_PUBLIC_SALE = START_TIME_PUBLIC_SALE + 1 days;
 
     // Free drop constant properties
-    uint256 PRICE_FREE_DROP = 0;
+    uint96 PRICE_FREE_DROP = 0;
     uint32 MINTER_MAX_MINTABLE_FREE_DROP = 100;
     uint32 MAX_MINTABLE_PER_ACCOUNT = 3;
 
     // Presale constant properties
-    uint256 PRICE_PRESALE = 50000000 gwei; // Price is 0.05 ETH
+    uint96 PRICE_PRESALE = 50000000 gwei; // Price is 0.05 ETH
     uint32 MINTER_MAX_MINTABLE_PRESALE = 45;
     uint32 MAX_MINTABLE_PER_ACCOUNT_PRESALE = 25; // There is a 25 tokens per account limit set on the presale.
 
     // Public sale constant properties
-    uint256 PRICE_PUBLIC_SALE = 100000000000000000; // Price is 0.1 ETH
+    uint96 PRICE_PUBLIC_SALE = 100000000000000000; // Price is 0.1 ETH
     uint32 MINTER_MAX_MINTABLE_PUBLIC_SALE = 700;
     uint32 MAX_MINTABLE_PER_ACCOUNT_PUBLIC_SALE = 50;
 

--- a/tests/modules/RangeEditionMinter.t.sol
+++ b/tests/modules/RangeEditionMinter.t.sol
@@ -9,7 +9,7 @@ import { BaseMinter } from "@modules/BaseMinter.sol";
 import { TestConfig } from "../TestConfig.sol";
 
 contract RangeEditionMinterTests is TestConfig {
-    uint256 constant PRICE = 1;
+    uint96 constant PRICE = 1;
 
     uint32 constant START_TIME = 100;
 
@@ -29,7 +29,7 @@ contract RangeEditionMinterTests is TestConfig {
     event RangeEditionMintCreated(
         address indexed edition,
         uint256 indexed mintId,
-        uint256 price,
+        uint96 price,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,
@@ -70,7 +70,7 @@ contract RangeEditionMinterTests is TestConfig {
     }
 
     function test_createEditionMint(
-        uint256 price,
+        uint96 price,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,


### PR DESCRIPTION
as long as price is < 79.23 bilion ethers, uint96 is sufficient
- reduces an sstore in RangeEditionMinter createEditionMint, and sload in mint
- reduces an sstore in MerkleDropMinter createEditionMint, and sload in mint