### PR TITLE
Change _nextMintId to be shared amongst all editions on a minter.

### DIFF
--- a/contracts/core/interfaces/IMinterModule.sol
+++ b/contracts/core/interfaces/IMinterModule.sol
@@ -238,11 +238,11 @@ interface IMinterModule is IERC165 {
     ) external view returns (uint256);
 
     /**
-     * @dev Returns the next mint ID for `edition`.
-     * A mint ID is assigned sequentially for each unique edition address,
-     * starting from (0, 1, 2, ...)
+     * @dev Returns the next mint ID.
+     * A mint ID is assigned sequentially starting from (0, 1, 2, ...),
+     * and is shared amonsgt all editions connected to the minter contract.
      */
-    function nextMintId(address edition) external view returns (uint256);
+    function nextMintId() external view returns (uint256);
 
     /**
      * @dev Returns the base mint data for (`edition`, `mintId`).

--- a/contracts/modules/BaseMinter.sol
+++ b/contracts/modules/BaseMinter.sol
@@ -30,9 +30,9 @@ abstract contract BaseMinter is IMinterModule, Ownable {
     // ================================
 
     /**
-     * @dev Maps an edition to the its next mint ID.
+     * @dev The next mint ID. Shared amongst all editions connected.
      */
-    mapping(address => uint256) private _nextMintIds;
+    uint256 private _nextMintId;
 
     /**
      * @dev Maps an edition and the mint ID to a mint instance.
@@ -214,8 +214,8 @@ abstract contract BaseMinter is IMinterModule, Ownable {
     /**
      * @inheritdoc IMinterModule
      */
-    function nextMintId(address edition) public view returns (uint256) {
-        return _nextMintIds[edition];
+    function nextMintId() public view returns (uint256) {
+        return _nextMintId;
     }
 
     /**
@@ -299,13 +299,13 @@ abstract contract BaseMinter is IMinterModule, Ownable {
         uint32 startTime,
         uint32 endTime
     ) internal onlyValidTimeRange(startTime, endTime) onlyEditionOwnerOrAdmin(edition) returns (uint256 mintId) {
-        mintId = _nextMintIds[edition];
+        mintId = _nextMintId;
 
         BaseData storage data = _baseData[edition][mintId];
         data.startTime = startTime;
         data.endTime = endTime;
 
-        _nextMintIds[edition] += 1;
+        _nextMintId = mintId + 1;
 
         emit MintConfigCreated(edition, msg.sender, mintId, startTime, endTime);
     }

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -97,14 +97,14 @@ contract MintControllerBaseTests is TestConfig {
     function test_createEditionMintIncremenetsNextMintId() external {
         SoundEditionV1 edition = _createEdition(EDITION_MAX_MINTABLE);
 
-        uint256 prevMintId = minter.nextMintId(address(edition));
+        uint256 prevMintId = minter.nextMintId();
         minter.createEditionMint(address(edition), START_TIME, END_TIME);
-        uint256 currentMintId = minter.nextMintId(address(edition));
+        uint256 currentMintId = minter.nextMintId();
         assertEq(currentMintId, prevMintId + 1);
 
         prevMintId = currentMintId;
         minter.createEditionMint(address(edition), START_TIME, END_TIME);
-        currentMintId = minter.nextMintId(address(edition));
+        currentMintId = minter.nextMintId();
         assertEq(currentMintId, prevMintId + 1);
     }
 


### PR DESCRIPTION
Pros:

- Reduces the average long term gas of adding a new edition from 20k to 5k.

Cons:

- Ids for a single minter may not be consecutive, making it hard to enumerate. If this is an issue, then we may wanna consider the spicier option of making the nextMintId a uint24, packing it to `_baseData[edition][0]`. Or close this and just stick to the current way.
