### PR TITLE
Update price_ var name

### DIFF
--- a/contracts/modules/FixedPriceSignatureMinter.sol
+++ b/contracts/modules/FixedPriceSignatureMinter.sol
@@ -23,7 +23,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
     /// @inheritdoc IFixedPriceSignatureMinter
     function createEditionMint(
         address edition,
-        uint96 price_,
+        uint96 price,
         address signer,
         uint32 maxMintable_,
         uint32 startTime,
@@ -33,14 +33,14 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
         if (signer == address(0)) revert SignerIsZeroAddress();
 
         EditionMintData storage data = _editionMintData[edition][mintId];
-        data.price = price_;
+        data.price = price;
         data.signer = signer;
         data.maxMintable = maxMintable_;
         // prettier-ignore
         emit FixedPriceSignatureMintCreated(
             edition,
             mintId,
-            price_,
+            price,
             signer,
             maxMintable_
         );

--- a/contracts/modules/MerkleDropMinter.sol
+++ b/contracts/modules/MerkleDropMinter.sol
@@ -34,7 +34,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
     function createEditionMint(
         address edition,
         bytes32 merkleRootHash,
-        uint96 price_,
+        uint96 price,
         uint32 startTime,
         uint32 endTime,
         uint32 maxMintable_,
@@ -44,7 +44,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
 
         EditionMintData storage data = _editionMintData[edition][mintId];
         data.merkleRootHash = merkleRootHash;
-        data.price = price_;
+        data.price = price;
         data.maxMintable = maxMintable_;
         data.maxMintablePerAccount = maxMintablePerAccount_;
         // prettier-ignore
@@ -52,7 +52,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
             edition,
             mintId,
             merkleRootHash,
-            price_,
+            price,
             startTime,
             endTime,
             maxMintable_,

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -47,7 +47,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     /// @inheritdoc IRangeEditionMinter
     function createEditionMint(
         address edition,
-        uint96 price_,
+        uint96 price,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,
@@ -60,7 +60,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         mintId = _createEditionMint(edition, startTime, endTime);
 
         EditionMintData storage data = _editionMintData[edition][mintId];
-        data.price = price_;
+        data.price = price;
         data.closingTime = closingTime;
         data.maxMintableLower = maxMintableLower;
         data.maxMintableUpper = maxMintableUpper;
@@ -70,7 +70,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         emit RangeEditionMintCreated(
             edition,
             mintId,
-            price_,
+            price,
             startTime,
             closingTime,
             endTime,

--- a/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
+++ b/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
@@ -65,7 +65,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
     /**
      * @dev Initializes a fixed-price signature mint instance.
      * @param edition The edition address.
-     * @param price_ The price to mint a token.
+     * @param price The price to mint a token.
      * @param signer The address of the signer that authorizes mints.
      * @param maxMintable_ The maximum number of tokens that can be minted.
      * @param startTime The time minting can begin.
@@ -74,7 +74,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
      */
     function createEditionMint(
         address edition,
-        uint96 price_,
+        uint96 price,
         address signer,
         uint32 maxMintable_,
         uint32 startTime,

--- a/contracts/modules/interfaces/IMerkleDropMinter.sol
+++ b/contracts/modules/interfaces/IMerkleDropMinter.sol
@@ -82,7 +82,7 @@ interface IMerkleDropMinter is IMinterModule {
      * @dev Initializes merkle drop mint instance.
      * @param edition Address of the song edition contract we are minting for.
      * @param merkleRootHash bytes32 hash of the Merkle tree representing eligible mints.
-     * @param price_ Sale price in ETH for minting a single token in `edition`.
+     * @param price Sale price in ETH for minting a single token in `edition`.
      * @param startTime Start timestamp of sale (in seconds since unix epoch).
      * @param endTime End timestamp of sale (in seconds since unix epoch).
      * @param maxMintable_ The maximum number of tokens that can can be minted for this sale.
@@ -92,7 +92,7 @@ interface IMerkleDropMinter is IMinterModule {
     function createEditionMint(
         address edition,
         bytes32 merkleRootHash,
-        uint96 price_,
+        uint96 price,
         uint32 startTime,
         uint32 endTime,
         uint32 maxMintable_,

--- a/contracts/modules/interfaces/IRangeEditionMinter.sol
+++ b/contracts/modules/interfaces/IRangeEditionMinter.sol
@@ -87,7 +87,7 @@ interface IRangeEditionMinter is IMinterModule {
      */
     function createEditionMint(
         address edition,
-        uint96 price_,
+        uint96 price,
         uint32 startTime,
         uint32 closingTime,
         uint32 endTime,

--- a/tests/mocks/MockMinter.sol
+++ b/tests/mocks/MockMinter.sol
@@ -23,8 +23,8 @@ contract MockMinter is BaseMinter {
         _mint(edition, mintId, quantity, affiliate);
     }
 
-    function setPrice(uint96 price_) external {
-        _currentPrice = price_;
+    function setPrice(uint96 price) external {
+        _currentPrice = price;
     }
 
     // ================================


### PR DESCRIPTION
Now that we no longer have a `price()` function, so mentions of `price_` can be changed to `price`