### PR TITLE
Remove receive function from sound edition. Secondary revenue goes to…

### DIFF
--- a/contracts/core/SoundEditionV1.sol
+++ b/contracts/core/SoundEditionV1.sol
@@ -342,15 +342,6 @@ contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721A
     }
 
     // ================================
-    // FALLBACK FUNCTIONS
-    // ================================
-
-    /**
-     * @dev receive secondary royalties
-     */
-    receive() external payable {}
-
-    // ================================
     // INTERNAL FUNCTIONS
     // ================================
 

--- a/tests/core/SoundEdition/payments.t.sol
+++ b/tests/core/SoundEdition/payments.t.sol
@@ -52,12 +52,7 @@ contract SoundEdition_payments is TestConfig {
         uint256 primaryETHSales = 10 ether;
         edition.mint{ value: primaryETHSales }(address(this), 1);
 
-        // secondary ETH royalty
-        uint256 secondaryETHSales = 2 ether;
-        (bool success, ) = address(edition).call{ value: secondaryETHSales }("");
-        require(success);
-
-        uint256 totalETHSales = primaryETHSales + secondaryETHSales;
+        uint256 totalETHSales = primaryETHSales;
 
         // withdraw
         uint256 preFundingRecipitentETHBal = FUNDING_RECIPIENT.balance;


### PR DESCRIPTION
… fundingRecipient.

Funds are designed to go directly to the fundingRecipient for secondary sales via royaltyInfo (eip-2981).
The only flow of funds is from initial mint