### PR TITLE
Affiliate mint event

### DIFF
--- a/contracts/core/SoundEditionV1.sol
+++ b/contracts/core/SoundEditionV1.sol
@@ -180,7 +180,7 @@ contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721A
     /**
      * @inheritdoc ISoundEditionV1
      */
-    function mint(address to, uint256 quantity) public payable {
+    function mint(address to, uint256 quantity) public payable returns (uint256 fromTokenId) {
         address caller = msg.sender;
         // Only allow calls if caller has minter role, admin role, or is the owner.
         if (!hasAnyRole(caller, MINTER_ROLE | ADMIN_ROLE) && caller != owner()) {
@@ -188,6 +188,7 @@ contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721A
         }
 
         uint256 totalMintedQty = _totalMinted();
+        fromTokenId = totalMintedQty + _startTokenId();
 
         unchecked {
             // Check if there are enough tokens to mint.
@@ -326,6 +327,13 @@ contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721A
     // =============================================================
     //               PUBLIC / EXTERNAL VIEW FUNCTIONS
     // =============================================================
+
+    /**
+     * @inheritdoc ISoundEditionV1
+     */
+    function nextTokenId() external view returns (uint256) {
+        return _nextTokenId();
+    }
 
     /**
      * @inheritdoc ISoundEditionV1

--- a/contracts/core/interfaces/IMinterModule.sol
+++ b/contracts/core/interfaces/IMinterModule.sol
@@ -48,31 +48,41 @@ interface IMinterModule is IERC165 {
     /**
      * @dev Emitted when the `paused` status of `edition` is updated.
      * @param edition The edition address.
-     * @param mintId The mint ID, to distinguish beteen multiple mints for the same edition.
-     * @param paused The new paused status.
+     * @param mintId  The mint ID, to distinguish beteen multiple mints for the same edition.
+     * @param paused  The new paused status.
      */
     event MintPausedSet(address indexed edition, uint128 mintId, bool paused);
 
     /**
      * @dev Emitted when the `paused` status of `edition` is updated.
-     * @param edition The edition address.
-     * @param mintId The mint ID, to distinguish beteen multiple mints for the same edition.
+     * @param edition   The edition address.
+     * @param mintId    The mint ID, to distinguish beteen multiple mints for the same edition.
      * @param startTime The start time of the mint.
-     * @param endTime The end time of the mint.
+     * @param endTime   The end time of the mint.
      */
     event TimeRangeSet(address indexed edition, uint128 indexed mintId, uint32 startTime, uint32 endTime);
 
     /**
      * @notice Emitted when the `affiliateFeeBPS` is updated.
+     * @param edition The edition address.
+     * @param mintId  The mint ID, to distinguish beteen multiple mints for the same edition.
+     * @param bps     The affiliate fee basis points.
      */
-    event AffiliateFeeSet(address indexed edition, uint128 indexed mintId, uint16 feeBPS);
+    event AffiliateFeeSet(address indexed edition, uint128 indexed mintId, uint16 bps);
 
     /**
      * @notice Emitted when a mint with an affiliate happens.
+     * @param edition      The edition address.
+     * @param mintId       The mint ID, to distinguish beteen multiple mints for the same edition.
+     * @param fromTokenId  The first token ID of the batch.
+     * @param quantity     The size of the batch.
+     * @param affiliateFee The cut paid to the affiliate.
+     * @param affiliate    The affiliate's address.
      */
     event MintedWithAffiliate(
         address indexed edition,
         uint128 indexed mintId,
+        uint32 fromTokenId,
         uint32 quantity,
         uint128 affiliateFee,
         address affiliate

--- a/contracts/core/interfaces/ISoundEditionV1.sol
+++ b/contracts/core/interfaces/ISoundEditionV1.sol
@@ -144,8 +144,9 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
      *
      * @param to       Address to mint to.
      * @param quantity Number of tokens to mint.
+     * @return fromTokenId The first token ID minted.
      */
-    function mint(address to, uint256 quantity) external payable;
+    function mint(address to, uint256 quantity) external payable returns (uint256 fromTokenId);
 
     /**
      * @dev Withdraws collected ETH royalties to the fundingRecipient
@@ -325,6 +326,12 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
      * @return The configured value.
      */
     function isMetadataFrozen() external view returns (bool);
+
+    /**
+     * @dev Returns the next token ID to be minted.
+     * @return The latest value.
+     */
+    function nextTokenId() external view returns (uint256);
 
     /**
      * @dev Returns the total amount of tokens minted.

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -30,6 +30,7 @@ contract MintControllerBaseTests is TestConfig {
     event MintedWithAffiliate(
         address indexed edition,
         uint128 indexed mintId,
+        uint32 fromTokenId,
         uint32 quantity,
         uint128 affiliateFee,
         address affiliate
@@ -416,8 +417,16 @@ contract MintControllerBaseTests is TestConfig {
             // The affiliate fees are deducted after the platform fees.
             expectedAffiliateFees = ((requiredEtherValue - expectedPlatformFees) * affiliateFeeBPS) / minter.MAX_BPS();
             // Expect an event.
+            uint32 fromTokenId = uint32(edition.nextTokenId());
             vm.expectEmit(true, true, true, true);
-            emit MintedWithAffiliate(address(edition), mintId, quantity, uint128(expectedAffiliateFees), affiliate);
+            emit MintedWithAffiliate(
+                address(edition),
+                mintId,
+                fromTokenId,
+                quantity,
+                uint128(expectedAffiliateFees),
+                affiliate
+            );
         }
 
         minter.mint{ value: requiredEtherValue }(address(edition), mintId, quantity, affiliate);


### PR DESCRIPTION
```solidity
/**
 * @notice Emitted when a mint with an affiliate happens.
 * @param edition      The edition address.
 * @param mintId       The mint ID, to distinguish beteen multiple mints for the same edition.
 * @param fromTokenId  The first token ID of the batch.
 * @param quantity     The size of the batch.
 * @param affiliateFee The cut paid to the affiliate.
 * @param affiliate    The affiliate's address.
 */
event MintedWithAffiliate(
    address indexed edition, 
    uint128 indexed mintId, 
    uint32 fromTokenId, 
    uint32 quantity, 
    uint128 affiliateFee, 
    address affiliate
);
```

Only emitted for affiliated mints.

To allow for easier matching of `Transfer` events to the `MintedWithAffiliate` event,
the following changes are made so that the event can emit the `fromTokenId` parameter efficiently:

- Add `fromTokenId` return parameter to `mint` in `ISoundEdition`.

- Add `nextTokenId` public function for convenience (used for testing, could be useful for clients). Technically, this is `totalMinted - 1`, but it's easy to mess up the formula if you are sleepy.
