### PR TITLE
Fixes GoldenEggMetadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ node_modules
 # Code coverage artifacts
 lcov.info
 /coverage/*
+
+.DS_Store

--- a/contracts/core/SoundEditionV1.sol
+++ b/contracts/core/SoundEditionV1.sol
@@ -327,14 +327,17 @@ contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721A
     /**
      * @inheritdoc ISoundEditionV1
      */
-    function setMintRandomnessLock(uint32 mintRandomnessTokenThreshold_) external onlyRolesOrOwner(ADMIN_ROLE) {
+    function setMintRandomnessTokenThreshold(uint32 mintRandomnessTokenThreshold_)
+        external
+        onlyRolesOrOwner(ADMIN_ROLE)
+    {
         if (mintRandomnessTokenThreshold_ < _totalMinted()) revert InvalidRandomnessLock();
 
         mintRandomnessTokenThreshold = mintRandomnessTokenThreshold_;
     }
 
     /// @inheritdoc ISoundEditionV1
-    function setRandomnessLockedTimestamp(uint32 mintRandomnessTimeThreshold_) external onlyRolesOrOwner(ADMIN_ROLE) {
+    function setRandomnessTimeThreshold(uint32 mintRandomnessTimeThreshold_) external onlyRolesOrOwner(ADMIN_ROLE) {
         mintRandomnessTimeThreshold = mintRandomnessTimeThreshold_;
     }
 

--- a/contracts/core/interfaces/ISoundEditionV1.sol
+++ b/contracts/core/interfaces/ISoundEditionV1.sol
@@ -251,7 +251,7 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
      *
      * @param mintRandomnessTokenThreshold The token quantity to be set.
      */
-    function setMintRandomnessLock(uint32 mintRandomnessTokenThreshold) external;
+    function setMintRandomnessTokenThreshold(uint32 mintRandomnessTokenThreshold) external;
 
     /**
      * @dev Sets the timestamp, after which `mintRandomness` gets locked.
@@ -261,7 +261,7 @@ interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
      *
      * @param mintRandomnessTimeThreshold_ The randomness timestamp to be set.
      */
-    function setRandomnessLockedTimestamp(uint32 mintRandomnessTimeThreshold_) external;
+    function setRandomnessTimeThreshold(uint32 mintRandomnessTimeThreshold_) external;
 
     // =============================================================
     //               PUBLIC / EXTERNAL VIEW FUNCTIONS

--- a/contracts/modules/GoldenEggMetadata.sol
+++ b/contracts/modules/GoldenEggMetadata.sol
@@ -32,8 +32,9 @@ contract GoldenEggMetadata is IGoldenEggMetadata {
         }
 
         if (
-            edition.totalMinted() >= mintRandomnessTokenThreshold ||
-            block.timestamp >= edition.mintRandomnessTimeThreshold()
+            edition.totalMinted() == edition.editionMaxMintable() ||
+            (edition.totalMinted() >= mintRandomnessTokenThreshold &&
+                block.timestamp >= edition.mintRandomnessTimeThreshold())
         ) {
             // Calculate number between 1 and mintRandomnessTokenThreshold.
             // mintRandomness is set during edition.mint() & corresponds to the blockhash.


### PR DESCRIPTION

@vigneshka The signature minter test case listed below is already covered by current tests using rang minter. No need to do it specifically with a signature minter minter because the minter doesn't have any bearing on the edition randomness vars. The range edition test cases listed are also covered. 

## fixed price signature:
randomness time = start time
randomness qty = maxMintable
- assert: after start time and below max mintable -> not revealed
- assert: after start time and at max mintable -> revealed

## range edition
randomness time  = closing time
randomness qty = lowerBound
assert: before closing time and above lowerBound -> not revealed
- assert: before closing time and at maxMintable -> revealed
- assert: after closing time and below lower bound -> not revealed
- assert: after closing time and above lower bound -> revealed