### PR TITLE
Fix setTimeRange on RangeEditionMinter

### DIFF
--- a/contracts/modules/BaseMinter.sol
+++ b/contracts/modules/BaseMinter.sol
@@ -86,8 +86,11 @@ abstract contract BaseMinter is IMinterModule {
         uint128 mintId,
         uint32 startTime,
         uint32 endTime
-    ) public virtual onlyEditionOwnerOrAdmin(edition) {
-        _setTimeRange(edition, mintId, startTime, endTime);
+    ) public virtual onlyEditionOwnerOrAdmin(edition) onlyValidTimeRange(startTime, endTime) {
+        _baseData[edition][mintId].startTime = startTime;
+        _baseData[edition][mintId].endTime = endTime;
+
+        emit TimeRangeSet(edition, mintId, startTime, endTime);
     }
 
     /**
@@ -251,26 +254,6 @@ abstract contract BaseMinter is IMinterModule {
         _nextMintId = mintId + 1;
 
         emit MintConfigCreated(edition, msg.sender, mintId, startTime, endTime, affiliateFeeBPS);
-    }
-
-    /**
-     * @dev Sets the time range for an edition mint.
-     * Note: If calling from a child contract, the child is responsible for access control.
-     * @param edition The edition address.
-     * @param mintId The ID for the mint instance.
-     * @param startTime The start time of the mint.
-     * @param endTime The end time of the mint.
-     */
-    function _setTimeRange(
-        address edition,
-        uint128 mintId,
-        uint32 startTime,
-        uint32 endTime
-    ) internal onlyValidTimeRange(startTime, endTime) {
-        _baseData[edition][mintId].startTime = startTime;
-        _baseData[edition][mintId].endTime = endTime;
-
-        emit TimeRangeSet(edition, mintId, startTime, endTime);
     }
 
     /**

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -125,8 +125,9 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         EditionMintData storage data = _editionMintData[edition][mintId];
         data.closingTime = closingTime;
 
-        // This calls _beforeSetTimeRange, which does the closingTime validation.
-        _setTimeRange(edition, mintId, startTime, endTime);
+        // This calls the overriden `setTimeRange`, which will check that
+        // `startTime < closingTime < endTime`.
+        RangeEditionMinter.setTimeRange(edition, mintId, startTime, endTime);
 
         emit ClosingTimeSet(edition, mintId, closingTime);
     }
@@ -141,9 +142,10 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         uint32 endTime
     ) public override(BaseMinter, IMinterModule) onlyEditionOwnerOrAdmin(edition) {
         EditionMintData storage data = _editionMintData[edition][mintId];
+
         if (!(startTime < data.closingTime && data.closingTime < endTime)) revert InvalidTimeRange();
 
-        _setTimeRange(edition, mintId, startTime, endTime);
+        BaseMinter.setTimeRange(edition, mintId, startTime, endTime);
     }
 
     /**


### PR DESCRIPTION
Previously, `setTimeRange` directly calls the internal `_setTimeRange`, which does not include the check on `closingTime`.