### PR TITLE
Use MerkleProofLib

### DIFF
--- a/contracts/modules/MerkleDropMinter.sol
+++ b/contracts/modules/MerkleDropMinter.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.16;
 
-import { MerkleProof } from "openzeppelin/utils/cryptography/MerkleProof.sol";
+import { MerkleProofLib } from "solady/utils/MerkleProofLib.sol";
 import { IERC165 } from "openzeppelin/utils/introspection/IERC165.sol";
 import { ISoundFeeRegistry } from "@core/interfaces/ISoundFeeRegistry.sol";
 import { BaseMinter } from "@modules/BaseMinter.sol";
@@ -92,7 +92,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
         data.totalMinted = _incrementTotalMinted(data.totalMinted, requestedQuantity, data.maxMintable);
 
         bytes32 leaf = keccak256(abi.encodePacked(msg.sender));
-        bool valid = MerkleProof.verify(merkleProof, data.merkleRootHash, leaf);
+        bool valid = MerkleProofLib.verify(merkleProof, data.merkleRootHash, leaf);
         if (!valid) revert InvalidMerkleProof();
 
         unchecked {


### PR DESCRIPTION
Drop in replacement. 

Saves 1.8k gas for a tree of 300 elements. 
6k+ gas if the tree has 2k elements.

https://github.com/Vectorized/solady/blob/main/src/utils/MerkleProofLib.sol

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/MerkleProof.sol

If there are issues, people will be already complaining on solmate v7's PRs or solady by now.