### PR TITLE
Change quantities to uint24

### DIFF
--- a/contracts/core/interfaces/IMinterModule.sol
+++ b/contracts/core/interfaces/IMinterModule.sol
@@ -86,8 +86,8 @@ interface IMinterModule is IERC165 {
     event Minted(
         address indexed edition,
         uint128 indexed mintId,
-        uint32 fromTokenId,
-        uint32 quantity,
+        uint24 fromTokenId,
+        uint24 quantity,
         uint128 requiredEtherValue,
         uint128 platformFee,
         uint128 affiliateFee,
@@ -110,7 +110,7 @@ interface IMinterModule is IERC165 {
      * @dev The number minted has exceeded the max mintable amount.
      * @param available The number of tokens remaining available for mint.
      */
-    error ExceedsAvailableSupply(uint32 available);
+    error ExceedsAvailableSupply(uint24 available);
 
     /**
      * @dev The mint is not opened.
@@ -243,7 +243,7 @@ interface IMinterModule is IERC165 {
         address edition,
         uint128 mintId,
         address minter,
-        uint32 quantity
+        uint24 quantity
     ) external view returns (uint128);
 
     /**

--- a/contracts/modules/BaseMinter.sol
+++ b/contracts/modules/BaseMinter.sol
@@ -184,7 +184,7 @@ abstract contract BaseMinter is IMinterModule {
         address edition,
         uint128 mintId,
         address minter,
-        uint32 quantity
+        uint24 quantity
     ) public view virtual override returns (uint128);
 
     // =============================================================
@@ -269,7 +269,7 @@ abstract contract BaseMinter is IMinterModule {
     function _mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
+        uint24 quantity,
         address affiliate
     ) internal {
         BaseData storage baseData = _baseData[edition][mintId];
@@ -313,7 +313,7 @@ abstract contract BaseMinter is IMinterModule {
 
         /* ------------------------- MINT --------------------------- */
 
-        uint32 fromTokenId = uint32(ISoundEditionV1(edition).mint{ value: remainingPayment }(msg.sender, quantity));
+        uint24 fromTokenId = uint24(ISoundEditionV1(edition).mint{ value: remainingPayment }(msg.sender, quantity));
 
         // Emit the event.
         emit Minted(
@@ -368,15 +368,15 @@ abstract contract BaseMinter is IMinterModule {
      * @return `totalMinted` + `quantity`.
      */
     function _incrementTotalMinted(
-        uint32 totalMinted,
-        uint32 quantity,
-        uint32 maxMintable
-    ) internal pure returns (uint32) {
+        uint24 totalMinted,
+        uint24 quantity,
+        uint24 maxMintable
+    ) internal pure returns (uint24) {
         unchecked {
             // Won't overflow as both are 32 bits.
             uint256 sum = uint256(totalMinted) + uint256(quantity);
             if (sum > maxMintable) {
-                uint32 available;
+                uint24 available;
                 // Note that the `maxMintable` may vary and drop over time
                 // and cause `totalMinted` to be greater than `maxMintable`.
                 if (maxMintable > totalMinted) {
@@ -384,7 +384,7 @@ abstract contract BaseMinter is IMinterModule {
                 }
                 revert ExceedsAvailableSupply(available);
             }
-            return uint32(sum);
+            return uint24(sum);
         }
     }
 }

--- a/contracts/modules/FixedPriceSignatureMinter.sol
+++ b/contracts/modules/FixedPriceSignatureMinter.sol
@@ -27,7 +27,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
      */
     bytes32 public constant MINT_TYPEHASH =
         keccak256(
-            "EditionInfo(address buyer,uint128 mintId,uint32 claimTicket,uint32 quantityLimit,address affiliate)"
+            "EditionInfo(address buyer,uint128 mintId,uint32 claimTicket,uint24 quantityLimit,address affiliate)"
         );
 
     // =============================================================
@@ -63,7 +63,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
         address edition,
         uint96 price,
         address signer,
-        uint32 maxMintable,
+        uint24 maxMintable,
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS
@@ -94,8 +94,8 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
-        uint32 signedQuantity,
+        uint24 quantity,
+        uint24 signedQuantity,
         address affiliate,
         bytes calldata signature,
         uint32 claimTicket
@@ -127,7 +127,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
         address edition,
         uint128 mintId,
         address, /* minter */
-        uint32 quantity
+        uint24 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {
             // Will not overflow, as `price` is 96 bits, and `quantity` is 32 bits. 96 + 32 = 128.
@@ -149,7 +149,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
             baseData.mintPaused,
             mintData.price,
             mintData.maxMintable,
-            type(uint32).max, // maxMintablePerAccount
+            type(uint24).max, // maxMintablePerAccount
             mintData.totalMinted,
             mintData.signer
         );
@@ -218,7 +218,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
         uint32 claimTicket,
         address edition,
         uint128 mintId,
-        uint32 signedQuantity,
+        uint24 signedQuantity,
         address affiliate
     ) private {
         bytes32 digest = keccak256(

--- a/contracts/modules/MerkleDropMinter.sol
+++ b/contracts/modules/MerkleDropMinter.sol
@@ -51,8 +51,8 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintable,
-        uint32 maxMintablePerAccount
+        uint24 maxMintable,
+        uint24 maxMintablePerAccount
     ) public returns (uint128 mintId) {
         mintId = _createEditionMint(edition, startTime, endTime, affiliateFeeBPS);
 
@@ -81,7 +81,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 requestedQuantity,
+        uint24 requestedQuantity,
         bytes32[] calldata merkleProof,
         address affiliate
     ) public payable {
@@ -122,7 +122,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
         address edition,
         uint128 mintId,
         address, /* minter */
-        uint32 quantity
+        uint24 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {
             // Will not overflow, as `price` is 96 bits, and `quantity` is 32 bits. 96 + 32 = 128.

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -50,9 +50,9 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         uint32 closingTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper,
-        uint32 maxMintablePerAccount
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper,
+        uint24 maxMintablePerAccount
     ) public onlyValidRangeTimes(startTime, closingTime, endTime) returns (uint128 mintId) {
         if (!(maxMintableLower <= maxMintableUpper)) revert InvalidMaxMintableRange(maxMintableLower, maxMintableUpper);
 
@@ -86,12 +86,12 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
+        uint24 quantity,
         address affiliate
     ) public payable {
         EditionMintData storage data = _editionMintData[edition][mintId];
 
-        uint32 _maxMintable = _getMaxMintable(data);
+        uint24 _maxMintable = _getMaxMintable(data);
 
         // Increase `totalMinted` by `quantity`.
         // Require that the increased value does not exceed `maxMintable`.
@@ -154,8 +154,8 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     function setMaxMintableRange(
         address edition,
         uint128 mintId,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper
     ) public onlyEditionOwnerOrAdmin(edition) {
         if (!(maxMintableLower <= maxMintableUpper)) revert InvalidMaxMintableRange(maxMintableLower, maxMintableUpper);
 
@@ -177,7 +177,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
         address edition,
         uint128 mintId,
         address, /* minter */
-        uint32 quantity
+        uint24 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {
             // Will not overflow, as `price` is 96 bits, and `quantity` is 32 bits. 96 + 32 = 128.
@@ -246,8 +246,8 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
      * @param data The edition mint data.
      * @return The computed value.
      */
-    function _getMaxMintable(EditionMintData storage data) internal view returns (uint32) {
-        uint32 _maxMintable;
+    function _getMaxMintable(EditionMintData storage data) internal view returns (uint24) {
+        uint24 _maxMintable;
         if (block.timestamp < data.closingTime) {
             _maxMintable = data.maxMintableUpper;
         } else {

--- a/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
+++ b/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
@@ -12,9 +12,9 @@ struct EditionMintData {
     // Whitelist signer address.
     address signer;
     // The maximum number of tokens that can can be minted for this sale.
-    uint32 maxMintable;
+    uint24 maxMintable;
     // The total number of tokens minted so far for this sale.
-    uint32 totalMinted;
+    uint24 totalMinted;
 }
 
 /**
@@ -26,9 +26,9 @@ struct MintInfo {
     uint16 affiliateFeeBPS;
     bool mintPaused;
     uint96 price;
-    uint32 maxMintable;
-    uint32 maxMintablePerAccount;
-    uint32 totalMinted;
+    uint24 maxMintable;
+    uint24 maxMintablePerAccount;
+    uint24 totalMinted;
     address signer;
 }
 
@@ -57,7 +57,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
         uint128 indexed mintId,
         uint96 price,
         address signer,
-        uint32 maxMintable,
+        uint24 maxMintable,
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS
@@ -106,7 +106,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
         address edition,
         uint96 price,
         address signer,
-        uint32 maxMintable_,
+        uint24 maxMintable_,
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS
@@ -124,8 +124,8 @@ interface IFixedPriceSignatureMinter is IMinterModule {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
-        uint32 signedQuantity,
+        uint24 quantity,
+        uint24 signedQuantity,
         address affiliate,
         bytes calldata signature,
         uint32 claimTicket

--- a/contracts/modules/interfaces/IMerkleDropMinter.sol
+++ b/contracts/modules/interfaces/IMerkleDropMinter.sol
@@ -12,11 +12,11 @@ struct EditionMintData {
     // The price at which each token will be sold, in ETH.
     uint96 price;
     // The maximum number of tokens that can can be minted for this sale.
-    uint32 maxMintable;
+    uint24 maxMintable;
     // The maximum number of tokens that a wallet can mint.
-    uint32 maxMintablePerAccount;
+    uint24 maxMintablePerAccount;
     // The total number of tokens minted so far for this sale.
-    uint32 totalMinted;
+    uint24 totalMinted;
 }
 
 /**
@@ -28,9 +28,9 @@ struct MintInfo {
     uint16 affiliateFeeBPS;
     bool mintPaused;
     uint96 price;
-    uint32 maxMintable;
-    uint32 maxMintablePerAccount;
-    uint32 totalMinted;
+    uint24 maxMintable;
+    uint24 maxMintablePerAccount;
+    uint24 totalMinted;
     bytes32 merkleRootHash;
 }
 
@@ -64,8 +64,8 @@ interface IMerkleDropMinter is IMinterModule {
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintable,
-        uint32 maxMintablePerAccount
+        uint24 maxMintable,
+        uint24 maxMintablePerAccount
     );
 
     /**
@@ -73,7 +73,7 @@ interface IMerkleDropMinter is IMinterModule {
      * @param recipient The address of the account that claimed the tokens.
      * @param quantity  The quantity of tokens claimed.
      */
-    event DropClaimed(address recipient, uint32 quantity);
+    event DropClaimed(address recipient, uint24 quantity);
 
     // =============================================================
     //                            ERRORS
@@ -112,8 +112,8 @@ interface IMerkleDropMinter is IMinterModule {
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintable_,
-        uint32 maxMintablePerAccount_
+        uint24 maxMintable_,
+        uint24 maxMintablePerAccount_
     ) external returns (uint128 mintId);
 
     /**
@@ -124,7 +124,7 @@ interface IMerkleDropMinter is IMinterModule {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 requestedQuantity,
+        uint24 requestedQuantity,
         bytes32[] calldata merkleProof,
         address affiliate
     ) external payable;

--- a/contracts/modules/interfaces/IRangeEditionMinter.sol
+++ b/contracts/modules/interfaces/IRangeEditionMinter.sol
@@ -14,13 +14,13 @@ struct EditionMintData {
     // `maxMintableUpper` to `maxMintableLower`.
     uint32 closingTime;
     // The total number of tokens minted. Includes permissioned mints.
-    uint32 totalMinted;
+    uint24 totalMinted;
     // The lower limit of the maximum number of tokens that can be minted.
-    uint32 maxMintableLower;
+    uint24 maxMintableLower;
     // The upper limit of the maximum number of tokens that can be minted.
-    uint32 maxMintableUpper;
+    uint24 maxMintableUpper;
     // The maximum number of tokens that a wallet can mint.
-    uint32 maxMintablePerAccount;
+    uint24 maxMintablePerAccount;
 }
 
 /**
@@ -32,10 +32,10 @@ struct MintInfo {
     uint16 affiliateFeeBPS;
     bool mintPaused;
     uint96 price;
-    uint32 maxMintableUpper;
-    uint32 maxMintableLower;
-    uint32 maxMintablePerAccount;
-    uint32 totalMinted;
+    uint24 maxMintableUpper;
+    uint24 maxMintableLower;
+    uint24 maxMintablePerAccount;
+    uint24 totalMinted;
     uint32 closingTime;
 }
 
@@ -71,9 +71,9 @@ interface IRangeEditionMinter is IMinterModule {
         uint32 closingTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper,
-        uint32 maxMintablePerAccount
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper,
+        uint24 maxMintablePerAccount
     );
 
     event ClosingTimeSet(address indexed edition, uint128 indexed mintId, uint32 closingTime);
@@ -88,8 +88,8 @@ interface IRangeEditionMinter is IMinterModule {
     event MaxMintableRangeSet(
         address indexed edition,
         uint128 indexed mintId,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper
     );
 
     // =============================================================
@@ -101,7 +101,7 @@ interface IRangeEditionMinter is IMinterModule {
      * @param maxMintableLower The lower limit of the maximum number of tokens that can be minted.
      * @param maxMintableUpper The upper limit of the maximum number of tokens that can be minted.
      */
-    error InvalidMaxMintableRange(uint32 maxMintableLower, uint32 maxMintableUpper);
+    error InvalidMaxMintableRange(uint24 maxMintableLower, uint24 maxMintableUpper);
 
     /**
      * @dev The number of tokens minted has exceeded the number allowed for each account.
@@ -134,9 +134,9 @@ interface IRangeEditionMinter is IMinterModule {
         uint32 closingTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper,
-        uint32 maxMintablePerAccount_
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper,
+        uint24 maxMintablePerAccount_
     ) external returns (uint128 mintId);
 
     /*
@@ -165,8 +165,8 @@ interface IRangeEditionMinter is IMinterModule {
     function setMaxMintableRange(
         address edition,
         uint128 mintId,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper
     ) external;
 
     /*
@@ -177,7 +177,7 @@ interface IRangeEditionMinter is IMinterModule {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
+        uint24 quantity,
         address affiliate
     ) external payable;
 

--- a/tests/TestConfig.sol
+++ b/tests/TestConfig.sol
@@ -19,7 +19,7 @@ contract TestConfig is Test {
     address constant FUNDING_RECIPIENT = address(99);
     uint16 constant ROYALTY_BPS = 100;
     address public constant ARTIST_ADMIN = address(8888888888);
-    uint32 constant EDITION_MAX_MINTABLE = type(uint32).max;
+    uint24 constant EDITION_MAX_MINTABLE = type(uint24).max;
     uint32 constant RANDOMNESS_LOCKED_TIMESTAMP = 200;
     address constant SOUND_FEE_ADDRESS = address(2222222222);
     uint16 constant PLATFORM_FEE_BPS = 200;

--- a/tests/invariants/RangeEditionMinterInvariants.sol
+++ b/tests/invariants/RangeEditionMinterInvariants.sol
@@ -73,7 +73,7 @@ contract RangeEditionMinterUpdater {
         minter.setTimeRange(address(edition), MINT_ID, startTime, closingTime, endTime);
     }
 
-    function setMaxMintableRange(uint32 maxMintableLower, uint32 maxMintableUpper) public {
+    function setMaxMintableRange(uint24 maxMintableLower, uint24 maxMintableUpper) public {
         minter.setMaxMintableRange(address(edition), MINT_ID, maxMintableLower, maxMintableUpper);
     }
 }

--- a/tests/mocks/MockMinter.sol
+++ b/tests/mocks/MockMinter.sol
@@ -28,7 +28,7 @@ contract MockMinter is BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
-        uint32 quantity,
+        uint24 quantity,
         address affiliate
     ) external payable {
         _mint(edition, mintId, quantity, affiliate);
@@ -42,7 +42,7 @@ contract MockMinter is BaseMinter {
         address, /* edition */
         uint128, /* mintId */
         address, /* minter */
-        uint32 quantity
+        uint24 quantity
     ) public view virtual override(BaseMinter) returns (uint128) {
         unchecked {
             // Will not overflow, as `price` is 96 bits, and `quantity` is 32 bits. 96 + 32 = 128.

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -30,8 +30,8 @@ contract MintControllerBaseTests is TestConfig {
     event Minted(
         address indexed edition,
         uint128 indexed mintId,
-        uint32 fromTokenId,
-        uint32 quantity,
+        uint24 fromTokenId,
+        uint24 quantity,
         uint128 requiredEtherValue,
         uint128 platformFee,
         uint128 affiliateFee,
@@ -51,7 +51,7 @@ contract MintControllerBaseTests is TestConfig {
         minter = new MockMinter(feeRegistry);
     }
 
-    function _createEdition(uint32 editionMaxMintable) internal returns (SoundEditionV1 edition) {
+    function _createEdition(uint24 editionMaxMintable) internal returns (SoundEditionV1 edition) {
         edition = SoundEditionV1(
             createSound(
                 SONG_NAME,
@@ -151,7 +151,7 @@ contract MintControllerBaseTests is TestConfig {
         uint96 price = 1;
         minter.setPrice(price);
 
-        uint32 quantity = 2;
+        uint24 quantity = 2;
 
         address buyer = getFundedAccount(123456789);
 
@@ -173,7 +173,7 @@ contract MintControllerBaseTests is TestConfig {
         uint96 price = 1;
         minter.setPrice(price);
 
-        uint32 quantity = 2;
+        uint24 quantity = 2;
 
         address buyer = getFundedAccount(123456789);
 
@@ -230,7 +230,7 @@ contract MintControllerBaseTests is TestConfig {
     function test_cantMintPastEditionMaxMintable() external {
         minter.setPrice(0);
 
-        uint32 maxSupply = 50;
+        uint24 maxSupply = 50;
         SoundEditionV1 edition1 = _createEdition(maxSupply);
 
         uint128 mintId1 = minter.createEditionMint(address(edition1), START_TIME, END_TIME, AFFILIATE_FEE_BPS);
@@ -296,7 +296,7 @@ contract MintControllerBaseTests is TestConfig {
         uint16 affiliateFeeBPS = 10;
         uint16 platformFeeBPS = 10;
         uint96 price = 1 ether;
-        uint32 quantity = 2;
+        uint24 quantity = 2;
 
         test_mintAndWithdrawlWithAffiliateAndPlatformFee(
             affiliateIsZeroAddress,
@@ -338,7 +338,7 @@ contract MintControllerBaseTests is TestConfig {
         affiliateFeeBPS = affiliateFeeBPS % minter.MAX_BPS();
         _test_setAffiliateFee(edition, mintId, affiliateFeeBPS);
 
-        uint32 quantity = 1;
+        uint24 quantity = 1;
         uint256 requiredEtherValue = minter.totalPrice(address(edition), mintId, address(this), quantity);
 
         address affiliate = getFundedAccount(123456789);
@@ -365,7 +365,7 @@ contract MintControllerBaseTests is TestConfig {
         platformFeeBPS = platformFeeBPS % minter.MAX_BPS();
         feeRegistry.setPlatformFeeBPS(platformFeeBPS);
 
-        uint32 quantity = 1;
+        uint24 quantity = 1;
         uint256 requiredEtherValue = minter.totalPrice(address(edition), mintId, address(this), quantity);
 
         address affiliate = getFundedAccount(123456789);
@@ -389,7 +389,7 @@ contract MintControllerBaseTests is TestConfig {
         uint16 affiliateFeeBPS,
         uint16 platformFeeBPS,
         uint96 price,
-        uint32 quantity
+        uint24 quantity
     ) public {
         price = price % 1e19;
         quantity = 1 + (quantity % 8);
@@ -421,7 +421,7 @@ contract MintControllerBaseTests is TestConfig {
             expectedAffiliateFees = ((requiredEtherValue - expectedPlatformFees) * affiliateFeeBPS) / minter.MAX_BPS();
         }
         // Expect an event.
-        uint32 fromTokenId = uint32(edition.nextTokenId());
+        uint24 fromTokenId = uint24(edition.nextTokenId());
         vm.expectEmit(true, true, true, true);
         emit Minted(
             address(edition),

--- a/tests/modules/FixedPriceSignatureMinter.t.sol
+++ b/tests/modules/FixedPriceSignatureMinter.t.sol
@@ -18,7 +18,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     using ECDSA for bytes32;
 
     uint96 constant PRICE = 1;
-    uint32 constant MAX_MINTABLE = 5;
+    uint24 constant MAX_MINTABLE = 5;
     uint256 constant SIGNER_PRIVATE_KEY = 1;
     uint128 constant MINT_ID = 0;
     uint32 constant START_TIME = 0;
@@ -26,8 +26,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     uint16 constant AFFILIATE_FEE_BPS = 0;
     address constant NULL_AFFILIATE = address(0);
     uint32 constant CLAIM_TICKET_0 = 0;
-    uint32 constant QUANTITY_1 = 1;
-    uint32 constant SIGNED_QUANTITY_1 = 1;
+    uint24 constant QUANTITY_1 = 1;
+    uint24 constant SIGNED_QUANTITY_1 = 1;
 
     // prettier-ignore
     event FixedPriceSignatureMintCreated(
@@ -35,7 +35,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         uint128 indexed mintId,
         uint96 price,
         address signer,
-        uint32 maxMintable,
+        uint24 maxMintable,
         uint32 startTime,
         uint32 endTime,
         uint16 affiliateFeeBps
@@ -50,7 +50,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         address minter,
         uint128 mintId,
         uint32 claimTicket,
-        uint32 signedQuantity,
+        uint24 signedQuantity,
         address affiliate
     ) internal returns (bytes memory) {
         bytes32 digest = keccak256(
@@ -194,8 +194,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     function test_mintWithUnderpaidReverts() public {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
-        uint32 quantity = 2;
-        uint32 signedQuantity = quantity;
+        uint24 quantity = 2;
+        uint24 signedQuantity = quantity;
 
         address buyer = getFundedAccount(1);
         bytes memory sig = _getSignature(
@@ -224,8 +224,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
         uint32 claimTicket = 0;
-        uint32 quantity = MAX_MINTABLE + 1;
-        uint32 signedQuantity = quantity;
+        uint24 quantity = MAX_MINTABLE + 1;
+        uint24 signedQuantity = quantity;
 
         address buyer = getFundedAccount(1);
         bytes memory sig1 = _getSignature(buyer, address(minter), MINT_ID, claimTicket, signedQuantity, NULL_AFFILIATE);
@@ -318,8 +318,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     function test_mintForNonExistentMintIdReverts() public {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
-        uint32 quantity = 2;
-        uint32 signedQuantity = quantity;
+        uint24 quantity = 2;
+        uint24 signedQuantity = quantity;
         address buyer = getFundedAccount(1);
 
         bytes memory sig = _getSignature(
@@ -353,8 +353,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     function test_mintUpdatesValuesAndMintsCorrectly() public {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
-        uint32 quantity = 2;
-        uint32 signedQuantity = quantity;
+        uint24 quantity = 2;
+        uint24 signedQuantity = quantity;
         address buyer = getFundedAccount(1);
 
         bytes memory sig = _getSignature(
@@ -391,8 +391,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     function test_multipleMintsFromSameBuyer() public {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
-        uint32 quantity = 1;
-        uint32 signedQuantity = 2;
+        uint24 quantity = 1;
+        uint24 signedQuantity = 2;
         uint32 claimTicket1 = 0;
         uint32 claimTicket2 = 1;
         address buyer = getFundedAccount(1);
@@ -581,7 +581,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         uint32[] memory tokensPerBuyer = new uint32[](1);
         tokensPerBuyer[0] = 1;
 
-        uint32 numOfTokensToBuy = 10;
+        uint24 numOfTokensToBuy = 10;
 
         uint32[] memory claimTickets = new uint32[](numOfTokensToBuy * 2);
 
@@ -593,7 +593,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
             address(edition),
             PRICE,
             _signerAddress(),
-            type(uint32).max, // max mintable
+            type(uint24).max, // max mintable
             START_TIME,
             END_TIME,
             AFFILIATE_FEE_BPS
@@ -668,7 +668,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
 
         uint32 expectedStartTime = 123;
         uint32 expectedEndTime = 502370;
-        uint32 expectedPrice = 1234071;
+        uint96 expectedPrice = 1234071;
 
         minter.createEditionMint(
             address(edition),
@@ -688,7 +688,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         assertEq(false, mintData.mintPaused);
         assertEq(expectedPrice, mintData.price);
         assertEq(_signerAddress(), mintData.signer);
-        assertEq(type(uint32).max, mintData.maxMintablePerAccount);
+        assertEq(type(uint24).max, mintData.maxMintablePerAccount);
         assertEq(MAX_MINTABLE, mintData.maxMintable);
         assertEq(0, mintData.totalMinted);
     }
@@ -740,8 +740,8 @@ contract FixedPriceSignatureMinterTests is TestConfig {
     function test_mintWithMoreThanSignedQuantityReverts() public {
         (SoundEditionV1 edition, FixedPriceSignatureMinter minter) = _createEditionAndMinter();
 
-        uint32 quantity = 2;
-        uint32 signedQuantity = 2;
+        uint24 quantity = 2;
+        uint24 signedQuantity = 2;
 
         address buyer = getFundedAccount(1);
         bytes memory sig = _getSignature(

--- a/tests/modules/GoldenEggMetadata.t.sol
+++ b/tests/modules/GoldenEggMetadata.t.sol
@@ -19,9 +19,9 @@ contract GoldenEggMetadataTests is TestConfig {
 
     uint16 constant AFFILIATE_FEE_BPS = 0;
 
-    uint32 constant MAX_MINTABLE_LOWER = 42;
+    uint24 constant MAX_MINTABLE_LOWER = 42;
 
-    uint32 constant MAX_MINTABLE_UPPER = 69;
+    uint24 constant MAX_MINTABLE_UPPER = 69;
 
     uint32 constant MINT_ID = 0;
 
@@ -62,7 +62,7 @@ contract GoldenEggMetadataTests is TestConfig {
             AFFILIATE_FEE_BPS,
             MAX_MINTABLE_LOWER,
             MAX_MINTABLE_UPPER,
-            type(uint32).max // maxMintablePerAccount
+            type(uint24).max // maxMintablePerAccount
         );
     }
 
@@ -70,7 +70,7 @@ contract GoldenEggMetadataTests is TestConfig {
         uint32 mintRandomnessTokenThreshold,
         uint32 mintRandomnessTimeThreshold,
         uint32 mintTime,
-        uint32 mintQuantity
+        uint24 mintQuantity
     ) external {
         vm.assume(mintQuantity > 0 && mintQuantity < 50);
         vm.assume(mintTime < END_TIME);
@@ -146,7 +146,7 @@ contract GoldenEggMetadataTests is TestConfig {
             CLOSING_TIME
         );
 
-        uint32 quantity = MAX_MINTABLE_UPPER;
+        uint24 quantity = MAX_MINTABLE_UPPER;
 
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
@@ -158,7 +158,7 @@ contract GoldenEggMetadataTests is TestConfig {
 
     // Test if tokenURI returns goldenEgg uri, when both randomnessLocked conditions have been met
     function test_getTokenURIAfterRandomnessLocked() external {
-        uint32 quantity = MAX_MINTABLE_LOWER - 1;
+        uint24 quantity = MAX_MINTABLE_LOWER - 1;
         (SoundEditionV1 edition, RangeEditionMinter minter, GoldenEggMetadata goldenEggModule) = _createEdition(
             CLOSING_TIME
         );
@@ -188,7 +188,7 @@ contract GoldenEggMetadataTests is TestConfig {
     function test_setMintRandomnessRevertsForNonOwner() external {
         (SoundEditionV1 edition, RangeEditionMinter minter, ) = _createEdition(CLOSING_TIME);
 
-        uint32 quantity = MAX_MINTABLE_LOWER - 1;
+        uint24 quantity = MAX_MINTABLE_LOWER - 1;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         address caller = getFundedAccount(1);
@@ -201,7 +201,7 @@ contract GoldenEggMetadataTests is TestConfig {
     function test_setMintRandomnessRevertsForLowValue() external {
         (SoundEditionV1 edition, RangeEditionMinter minter, ) = _createEdition(CLOSING_TIME);
 
-        uint32 quantity = MAX_MINTABLE_LOWER - 1;
+        uint24 quantity = MAX_MINTABLE_LOWER - 1;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         vm.expectRevert(ISoundEditionV1.InvalidRandomnessLock.selector);
@@ -214,7 +214,7 @@ contract GoldenEggMetadataTests is TestConfig {
             CLOSING_TIME
         );
 
-        uint32 quantity = MAX_MINTABLE_LOWER - 1;
+        uint24 quantity = MAX_MINTABLE_LOWER - 1;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
@@ -239,7 +239,7 @@ contract GoldenEggMetadataTests is TestConfig {
         address admin = address(789);
         edition.grantRoles(admin, edition.ADMIN_ROLE());
 
-        uint32 quantity = MAX_MINTABLE_LOWER - 1;
+        uint24 quantity = MAX_MINTABLE_LOWER - 1;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
@@ -278,7 +278,7 @@ contract GoldenEggMetadataTests is TestConfig {
             randomnessTimeThreshold
         );
 
-        uint32 quantity = MAX_MINTABLE_LOWER;
+        uint24 quantity = MAX_MINTABLE_LOWER;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
@@ -305,7 +305,7 @@ contract GoldenEggMetadataTests is TestConfig {
         address admin = address(789);
         edition.grantRoles(admin, edition.ADMIN_ROLE());
 
-        uint32 quantity = MAX_MINTABLE_LOWER;
+        uint24 quantity = MAX_MINTABLE_LOWER;
         minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);

--- a/tests/modules/MerkleDropMinter.t.sol
+++ b/tests/modules/MerkleDropMinter.t.sol
@@ -35,9 +35,9 @@ contract MerkleDropMinterTests is TestConfig {
     }
 
     function _createEditionAndMinter(
-        uint32 _price,
-        uint32 _maxMintable,
-        uint32 _maxMintablePerAccount
+        uint24 _price,
+        uint24 _maxMintable,
+        uint24 _maxMintablePerAccount
     )
         internal
         returns (
@@ -66,7 +66,7 @@ contract MerkleDropMinterTests is TestConfig {
     }
 
     function test_canMintMultipleTimesLessThanMaxMintablePerAccount() public {
-        uint32 maxPerAccount = 2;
+        uint24 maxPerAccount = 2;
         (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(
             0,
             6,
@@ -79,7 +79,7 @@ contract MerkleDropMinterTests is TestConfig {
 
         vm.warp(START_TIME);
 
-        uint32 requestedQuantity = 1;
+        uint24 requestedQuantity = 1;
         vm.prank(accounts[1]);
         minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
         user1Balance = edition.balanceOf(accounts[1]);
@@ -93,8 +93,8 @@ contract MerkleDropMinterTests is TestConfig {
     }
 
     function test_cannotClaimMoreThanMaxMintablePerAccount() public {
-        uint32 maxPerAccount = 1;
-        uint32 requestedQuantity = 2;
+        uint24 maxPerAccount = 1;
+        uint24 requestedQuantity = 2;
         (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(
             0,
             6,
@@ -110,8 +110,8 @@ contract MerkleDropMinterTests is TestConfig {
     }
 
     function test_cannotClaimMoreThanMaxMintable() public {
-        uint32 maxPerAccount = 3;
-        uint32 requestedQuantity = 3;
+        uint24 maxPerAccount = 3;
+        uint24 requestedQuantity = 3;
 
         (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(
             0,
@@ -132,13 +132,13 @@ contract MerkleDropMinterTests is TestConfig {
 
         vm.warp(START_TIME);
         vm.prank(accounts[0]);
-        uint32 requestedQuantity = 1;
+        uint24 requestedQuantity = 1;
         vm.expectRevert(IMerkleDropMinter.InvalidMerkleProof.selector);
         minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
     }
 
     function test_canGetMintedTallyForAccount() public {
-        uint32 maxMintablePerAccount = 1;
+        uint24 maxMintablePerAccount = 1;
         (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(
             0,
             6,
@@ -149,7 +149,7 @@ contract MerkleDropMinterTests is TestConfig {
         vm.warp(START_TIME);
         vm.prank(accounts[0]);
 
-        uint32 requestedQuantity = maxMintablePerAccount;
+        uint24 requestedQuantity = maxMintablePerAccount;
         minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
 
         uint256 mintedTally = minter.mintedTallies(address(edition), mintId, accounts[0]);
@@ -184,8 +184,8 @@ contract MerkleDropMinterTests is TestConfig {
 
         uint32 expectedStartTime = 123;
         uint32 expectedEndTime = 502370;
-        uint32 expectedMaxMintable = 39730302;
-        uint32 expectedMaxPerWallet = 397;
+        uint24 expectedMaxMintable = 3973030;
+        uint24 expectedMaxPerWallet = 397;
 
         uint128 mintId = minter.createEditionMint(
             address(edition),

--- a/tests/modules/MintersIntegration.t.sol
+++ b/tests/modules/MintersIntegration.t.sol
@@ -19,18 +19,18 @@ contract MintersIntegration is TestConfig {
 
     // Free drop constant properties
     uint96 PRICE_FREE_DROP = 0;
-    uint32 MINTER_MAX_MINTABLE_FREE_DROP = 100;
-    uint32 MAX_MINTABLE_PER_ACCOUNT = 3;
+    uint24 MINTER_MAX_MINTABLE_FREE_DROP = 100;
+    uint24 MAX_MINTABLE_PER_ACCOUNT = 3;
 
     // Presale constant properties
     uint96 PRICE_PRESALE = 50000000 gwei; // Price is 0.05 ETH
-    uint32 MINTER_MAX_MINTABLE_PRESALE = 45;
-    uint32 MAX_MINTABLE_PER_ACCOUNT_PRESALE = 25; // There is a 25 tokens per account limit set on the presale.
+    uint24 MINTER_MAX_MINTABLE_PRESALE = 45;
+    uint24 MAX_MINTABLE_PER_ACCOUNT_PRESALE = 25; // There is a 25 tokens per account limit set on the presale.
 
     // Public sale constant properties
     uint96 PRICE_PUBLIC_SALE = 100000000000000000; // Price is 0.1 ETH
-    uint32 MINTER_MAX_MINTABLE_PUBLIC_SALE = 700;
-    uint32 MAX_MINTABLE_PER_ACCOUNT_PUBLIC_SALE = 50;
+    uint24 MINTER_MAX_MINTABLE_PUBLIC_SALE = 700;
+    uint24 MAX_MINTABLE_PER_ACCOUNT_PUBLIC_SALE = 50;
 
     address[] public userAccounts = [
         getFundedAccount(1), // User 1 - participate in free drop
@@ -68,7 +68,7 @@ contract MintersIntegration is TestConfig {
       - Public Sale: executed as 1 day long public sale
     */
     function test_Glasshouse() public {
-        uint32 EDITION_MAX_MINTABLE = 1000;
+        uint24 EDITION_MAX_MINTABLE = 1000;
         // Setup Glass house sound edition
         edition = SoundEditionV1(
             createSound(

--- a/tests/modules/RangeEditionMinter.t.sol
+++ b/tests/modules/RangeEditionMinter.t.sol
@@ -20,13 +20,13 @@ contract RangeEditionMinterTests is TestConfig {
 
     uint16 constant AFFILIATE_FEE_BPS = 0;
 
-    uint32 constant MAX_MINTABLE_LOWER = 5;
+    uint24 constant MAX_MINTABLE_LOWER = 5;
 
-    uint32 constant MAX_MINTABLE_UPPER = 10;
+    uint24 constant MAX_MINTABLE_UPPER = 10;
 
     uint128 constant MINT_ID = 0;
 
-    uint32 constant MAX_MINTABLE_PER_ACCOUNT = 0;
+    uint24 constant MAX_MINTABLE_PER_ACCOUNT = 0;
 
     // prettier-ignore
     event RangeEditionMintCreated(
@@ -37,9 +37,9 @@ contract RangeEditionMinterTests is TestConfig {
         uint32 closingTime,
         uint32 endTime,
         uint16 affiliateFeeBps,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper,
-        uint32 maxMintablePerAccount
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper,
+        uint24 maxMintablePerAccount
     );
 
     event ClosingTimeSet(address indexed edition, uint128 indexed mintId, uint32 closingTime);
@@ -47,13 +47,13 @@ contract RangeEditionMinterTests is TestConfig {
     event MaxMintableRangeSet(
         address indexed edition,
         uint128 indexed mintId,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper
     );
 
     event TimeRangeSet(address indexed edition, uint128 indexed mintId, uint32 startTime, uint32 endTime);
 
-    function _createEditionAndMinter(uint32 _maxMintablePerAccount)
+    function _createEditionAndMinter(uint24 _maxMintablePerAccount)
         internal
         returns (SoundEditionV1 edition, RangeEditionMinter minter)
     {
@@ -82,9 +82,9 @@ contract RangeEditionMinterTests is TestConfig {
         uint32 closingTime,
         uint32 endTime,
         uint16 affiliateFeeBPS,
-        uint32 maxMintableLower,
-        uint32 maxMintableUpper,
-        uint32 maxMintablePerAccount
+        uint24 maxMintableLower,
+        uint24 maxMintableUpper,
+        uint24 maxMintablePerAccount
     ) public {
         SoundEditionV1 edition = SoundEditionV1(
             createSound(
@@ -157,7 +157,7 @@ contract RangeEditionMinterTests is TestConfig {
             assertEq(mintInfo.startTime, startTime);
             assertEq(mintInfo.closingTime, closingTime);
             assertEq(mintInfo.endTime, endTime);
-            assertEq(mintInfo.totalMinted, uint32(0));
+            assertEq(mintInfo.totalMinted, uint24(0));
             assertEq(mintInfo.maxMintableLower, maxMintableLower);
             assertEq(mintInfo.maxMintableUpper, maxMintableUpper);
         }
@@ -223,13 +223,13 @@ contract RangeEditionMinterTests is TestConfig {
     }
 
     function test_mintUpdatesValuesAndMintsCorrectly() public {
-        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint32).max);
+        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint24).max);
 
         vm.warp(START_TIME);
 
         address caller = getFundedAccount(1);
 
-        uint32 quantity = 2;
+        uint24 quantity = 2;
 
         MintInfo memory data = minter.mintInfo(address(edition), MINT_ID);
 
@@ -246,7 +246,7 @@ contract RangeEditionMinterTests is TestConfig {
     }
 
     function test_mintRevertForUnderpaid() public {
-        uint32 quantity = 2;
+        uint24 quantity = 2;
         (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(quantity);
 
         vm.warp(START_TIME);
@@ -264,9 +264,9 @@ contract RangeEditionMinterTests is TestConfig {
     }
 
     function test_mintRevertsForMintNotOpen() public {
-        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint32).max);
+        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint24).max);
 
-        uint32 quantity = 1;
+        uint24 quantity = 1;
 
         vm.warp(START_TIME - 1);
         vm.expectRevert(
@@ -290,13 +290,13 @@ contract RangeEditionMinterTests is TestConfig {
         minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
     }
 
-    function test_mintRevertsForSoldOut(uint32 quantityToBuyBeforeClosing, uint32 quantityToBuyAfterClosing) public {
-        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint32).max);
+    function test_mintRevertsForSoldOut(uint24 quantityToBuyBeforeClosing, uint24 quantityToBuyAfterClosing) public {
+        (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(type(uint24).max);
 
-        quantityToBuyBeforeClosing = uint32((quantityToBuyBeforeClosing % uint256(MAX_MINTABLE_UPPER * 2)) + 1);
-        quantityToBuyAfterClosing = uint32((quantityToBuyAfterClosing % uint256(MAX_MINTABLE_UPPER * 2)) + 1);
+        quantityToBuyBeforeClosing = uint24((quantityToBuyBeforeClosing % uint256(MAX_MINTABLE_UPPER * 2)) + 1);
+        quantityToBuyAfterClosing = uint24((quantityToBuyAfterClosing % uint256(MAX_MINTABLE_UPPER * 2)) + 1);
 
-        uint32 totalMinted;
+        uint24 totalMinted;
 
         if (quantityToBuyBeforeClosing > MAX_MINTABLE_UPPER) {
             vm.expectRevert(
@@ -314,7 +314,7 @@ contract RangeEditionMinterTests is TestConfig {
         );
 
         if (totalMinted + quantityToBuyAfterClosing > MAX_MINTABLE_LOWER) {
-            uint32 available = MAX_MINTABLE_LOWER > totalMinted ? MAX_MINTABLE_LOWER - totalMinted : 0;
+            uint24 available = MAX_MINTABLE_LOWER > totalMinted ? MAX_MINTABLE_LOWER - totalMinted : 0;
             vm.expectRevert(abi.encodeWithSelector(IMinterModule.ExceedsAvailableSupply.selector, available));
         }
         vm.warp(CLOSING_TIME);
@@ -333,10 +333,10 @@ contract RangeEditionMinterTests is TestConfig {
     }
 
     function test_mintBeforeAndAfterClosingTimeBaseCase() public {
-        uint32 quantity = 1;
+        uint24 quantity = 1;
         (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(quantity);
-        uint32 maxMintableLower = 0;
-        uint32 maxMintableUpper = 1;
+        uint24 maxMintableLower = 0;
+        uint24 maxMintableUpper = 1;
         minter.setMaxMintableRange(address(edition), MINT_ID, maxMintableLower, maxMintableUpper);
 
         vm.warp(START_TIME);
@@ -412,7 +412,7 @@ contract RangeEditionMinterTests is TestConfig {
         }
     }
 
-    function test_setMaxMintableRange(uint32 maxMintableLower, uint32 maxMintableUpper) public {
+    function test_setMaxMintableRange(uint24 maxMintableLower, uint24 maxMintableUpper) public {
         (SoundEditionV1 edition, RangeEditionMinter minter) = _createEditionAndMinter(0);
 
         bool hasRevert;
@@ -469,8 +469,8 @@ contract RangeEditionMinterTests is TestConfig {
 
         uint32 expectedStartTime = 123;
         uint32 expectedEndTime = 502370;
-        uint32 expectedPrice = 1234071;
-        uint32 expectedMaxAllowedPerWallet = 937;
+        uint96 expectedPrice = 1234071;
+        uint24 expectedMaxAllowedPerWallet = 937;
 
         minter.createEditionMint(
             address(edition),


### PR DESCRIPTION
2^24 is 16,777,216 which is a sufficient quantity upper bound
Changing these fields from uint32 -> uint24 will aid in followup change to pack data into BaseMinter aux storage

Fixes: PRO-388