### PR TITLE
Removes gen:ids from pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-pnpm run solhint && pnpm gen:ids && git add --all && git commit --amend --no-edit
+pnpm run solhint


### PR DESCRIPTION
It often results in the interfaceIds file getting deleted if you cancel, then try `--no-verify`. Given the contracts are now deployed on mainnet, we shouldn't need it. 