### PR TITLE
Fix Natspec

### DIFF
--- a/contracts/core/SoundCreatorV1.sol
+++ b/contracts/core/SoundCreatorV1.sol
@@ -37,7 +37,7 @@ import { OwnableRoles } from "solady/auth/OwnableRoles.sol";
 
 /**
  * @title SoundCreatorV1
- * @notice A factory that deploys minimal proxies of `SoundEditionV1.sol`.
+ * @dev A factory that deploys minimal proxies of `SoundEditionV1.sol`.
  * @dev The proxies are OpenZeppelin's Clones implementation of https://eips.ethereum.org/EIPS/eip-1167
  */
 contract SoundCreatorV1 is ISoundCreatorV1, OwnableRoles {

--- a/contracts/core/SoundEditionV1.sol
+++ b/contracts/core/SoundEditionV1.sol
@@ -44,7 +44,7 @@ import { ArweaveURILib } from "./utils/ArweaveURILib.sol";
 
 /**
  * @title SoundEditionV1
- * @notice The Sound Edition contract - a creator-owned, modifiable implementation of ERC721A.
+ * @dev The Sound Edition contract - a creator-owned, modifiable implementation of ERC721A.
  */
 contract SoundEditionV1 is ISoundEditionV1, ERC721AQueryableUpgradeable, ERC721ABurnableUpgradeable, OwnableRoles {
     using ArweaveURILib for ArweaveURILib.URI;

--- a/contracts/core/interfaces/IMetadataModule.sol
+++ b/contracts/core/interfaces/IMetadataModule.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.16;
 
 /**
  * @title IMetadataModule
- * @notice The interface for custom metadata modules.
+ * @dev The interface for custom metadata modules.
  */
 interface IMetadataModule {
     /**

--- a/contracts/core/interfaces/IMinterModule.sol
+++ b/contracts/core/interfaces/IMinterModule.sol
@@ -75,7 +75,7 @@ interface IMinterModule is IERC165 {
      * @param edition            The edition address.
      * @param mintId             The mint ID, to distinguish between multiple mints for
      *                           the same edition.
-     * @param buyer              The buyer address.
+     * @param to                 The address to mint to.
      * @param fromTokenId        The first token ID of the batch.
      * @param quantity           The size of the batch.
      * @param requiredEtherValue Total amount of Ether required for payment.
@@ -87,7 +87,7 @@ interface IMinterModule is IERC165 {
     event Minted(
         address indexed edition,
         uint128 indexed mintId,
-        address indexed buyer,
+        address indexed to,
         uint32 fromTokenId,
         uint32 quantity,
         uint128 requiredEtherValue,
@@ -237,14 +237,14 @@ interface IMinterModule is IERC165 {
      * @dev The total price for `quantity` tokens for (`edition`, `mintId`).
      * @param edition   The edition's address.
      * @param mintId    The mint ID.
-     * @param mintId    The minter's address.
+     * @param to        The address to mint to.
      * @param quantity  The number of tokens to mint.
      * @return The computed value.
      */
     function totalPrice(
         address edition,
         uint128 mintId,
-        address minter,
+        address to,
         uint32 quantity
     ) external view returns (uint128);
 

--- a/contracts/core/interfaces/IMinterModule.sol
+++ b/contracts/core/interfaces/IMinterModule.sol
@@ -6,7 +6,7 @@ import { ISoundFeeRegistry } from "./ISoundFeeRegistry.sol";
 
 /**
  * @title IMinterModule
- * @notice The interface for Sound protocol minter modules.
+ * @dev The interface for Sound protocol minter modules.
  */
 interface IMinterModule is IERC165 {
     // =============================================================
@@ -63,7 +63,7 @@ interface IMinterModule is IERC165 {
     event TimeRangeSet(address indexed edition, uint128 indexed mintId, uint32 startTime, uint32 endTime);
 
     /**
-     * @notice Emitted when the `affiliateFeeBPS` is updated.
+     * @dev Emitted when the `affiliateFeeBPS` is updated.
      * @param edition The edition address.
      * @param mintId  The mint ID, to distinguish between multiple mints for the same edition.
      * @param bps     The affiliate fee basis points.
@@ -71,7 +71,7 @@ interface IMinterModule is IERC165 {
     event AffiliateFeeSet(address indexed edition, uint128 indexed mintId, uint16 bps);
 
     /**
-     * @notice Emitted when a mint happens.
+     * @dev Emitted when a mint happens.
      * @param edition            The edition address.
      * @param mintId             The mint ID, to distinguish between multiple mints for
      *                           the same edition.

--- a/contracts/core/interfaces/ISoundCreatorV1.sol
+++ b/contracts/core/interfaces/ISoundCreatorV1.sol
@@ -5,7 +5,7 @@ import { IMetadataModule } from "./IMetadataModule.sol";
 
 /**
  * @title ISoundCreatorV1
- * @notice The interface for the Sound edition factory.
+ * @dev The interface for the Sound edition factory.
  */
 interface ISoundCreatorV1 {
     // =============================================================

--- a/contracts/core/interfaces/ISoundEditionV1.sol
+++ b/contracts/core/interfaces/ISoundEditionV1.sol
@@ -55,7 +55,7 @@ struct EditionInfo {
 
 /**
  * @title ISoundEditionV1
- * @notice The interface for Sound edition contracts.
+ * @dev The interface for Sound edition contracts.
  */
 interface ISoundEditionV1 is IERC721AUpgradeable, IERC2981Upgradeable {
     // =============================================================

--- a/contracts/modules/BaseMinter.sol
+++ b/contracts/modules/BaseMinter.sol
@@ -184,7 +184,7 @@ abstract contract BaseMinter is IMinterModule {
     function totalPrice(
         address edition,
         uint128 mintId,
-        address minter,
+        address to,
         uint32 quantity
     ) public view virtual override returns (uint128);
 

--- a/contracts/modules/EditionMaxMinter.sol
+++ b/contracts/modules/EditionMaxMinter.sol
@@ -123,7 +123,7 @@ contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {
     function totalPrice(
         address edition,
         uint128 mintId,
-        address, /* minter */
+        address, /* to */
         uint32 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {

--- a/contracts/modules/EditionMaxMinter.sol
+++ b/contracts/modules/EditionMaxMinter.sol
@@ -11,7 +11,7 @@ import { ISoundEditionV1, EditionInfo } from "@core/interfaces/ISoundEditionV1.s
 
 /*
  * @title EditionMaxMinter
- * @notice Module for unpermissioned mints of Sound editions.
+ * @dev Module for unpermissioned mints of Sound editions.
  * @author Sound.xyz
  */
 contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {

--- a/contracts/modules/FixedPriceSignatureMinter.sol
+++ b/contracts/modules/FixedPriceSignatureMinter.sol
@@ -163,7 +163,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
     function totalPrice(
         address edition,
         uint128 mintId,
-        address, /* minter */
+        address, /* to */
         uint32 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {

--- a/contracts/modules/MerkleDropMinter.sol
+++ b/contracts/modules/MerkleDropMinter.sol
@@ -167,7 +167,7 @@ contract MerkleDropMinter is IMerkleDropMinter, BaseMinter {
     function totalPrice(
         address edition,
         uint128 mintId,
-        address, /* minter */
+        address, /* to */
         uint32 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -11,7 +11,7 @@ import { ISoundEditionV1 } from "@core/interfaces/ISoundEditionV1.sol";
 
 /*
  * @title RangeEditionMinter
- * @notice Module for range edition mints of Sound editions.
+ * @dev Module for range edition mints of Sound editions.
  * @author Sound.xyz
  */
 contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -194,7 +194,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     function totalPrice(
         address edition,
         uint128 mintId,
-        address, /* minter */
+        address, /* to */
         uint32 quantity
     ) public view virtual override(BaseMinter, IMinterModule) returns (uint128) {
         unchecked {

--- a/contracts/modules/interfaces/IEditionMaxMinter.sol
+++ b/contracts/modules/interfaces/IEditionMaxMinter.sol
@@ -92,15 +92,13 @@ interface IEditionMaxMinter is IMinterModule {
     //               PUBLIC / EXTERNAL WRITE FUNCTIONS
     // =============================================================
 
-    /*
+    /**
      * @dev Initializes a range mint instance
      * @param edition               Address of the song edition contract we are minting for.
      * @param price                 Sale price in ETH for minting a single token in `edition`.
      * @param startTime             Start timestamp of sale (in seconds since unix epoch).
      * @param endTime               End timestamp of sale (in seconds since unix epoch).
      * @param affiliateFeeBPS       The affiliate fee in basis points.
-     * @param maxMintableLower      The lower limit of the maximum number of tokens that can be minted.
-     * @param maxMintableUpper      The upper limit of the maximum number of tokens that can be minted.
      * @param maxMintablePerAccount The maximum number of tokens that can be minted by an account.
      * @return mintId The ID for the new mint instance.
      */
@@ -113,7 +111,7 @@ interface IEditionMaxMinter is IMinterModule {
         uint32 maxMintablePerAccount
     ) external returns (uint128 mintId);
 
-    /*
+    /**
      * @dev Mints tokens for a given edition.
      * @param edition   Address of the song edition contract we are minting for.
      * @param mintId    The mint ID.
@@ -127,7 +125,7 @@ interface IEditionMaxMinter is IMinterModule {
         address affiliate
     ) external payable;
 
-    /*
+    /**
      * @dev Sets the `price` for (`edition`, `mintId`).
      * @param edition Address of the song edition contract we are minting for.
      * @param mintId  The mint ID.
@@ -139,7 +137,7 @@ interface IEditionMaxMinter is IMinterModule {
         uint96 price
     ) external;
 
-    /*
+    /**
      * @dev Sets the `maxMintablePerAccount` for (`edition`, `mintId`).
      * @param edition               Address of the song edition contract we are minting for.
      * @param mintId                The mint ID.

--- a/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
+++ b/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
@@ -155,7 +155,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
         uint32 claimTicket
     ) external payable;
 
-    /*
+    /**
      * @dev Sets the `maxMintable` for (`edition`, `mintId`).
      * @param edition               Address of the song edition contract we are minting for.
      * @param mintId                The mint ID.
@@ -167,7 +167,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
         uint32 maxMintable
     ) external;
 
-    /*
+    /**
      * @dev Sets the `price` for (`edition`, `mintId`).
      * @param edition Address of the song edition contract we are minting for.
      * @param mintId  The mint ID.
@@ -179,7 +179,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
         uint96 price
     ) external;
 
-    /*
+    /**
      * @dev Sets the `maxMintablePerAccount` for (`edition`, `mintId`).
      * @param edition Address of the song edition contract we are minting for.
      * @param mintId  The mint ID.

--- a/contracts/modules/interfaces/IGoldenEggMetadata.sol
+++ b/contracts/modules/interfaces/IGoldenEggMetadata.sol
@@ -6,7 +6,7 @@ import { ISoundEditionV1 } from "@core/interfaces/ISoundEditionV1.sol";
 
 /**
  * @title IGoldenEggMetadata
- * @notice The interface for the Sound Golden Egg metadata module.
+ * @dev The interface for the Sound Golden Egg metadata module.
  */
 interface IGoldenEggMetadata is IMetadataModule {
     /**

--- a/contracts/modules/interfaces/IMerkleDropMinter.sol
+++ b/contracts/modules/interfaces/IMerkleDropMinter.sol
@@ -171,7 +171,7 @@ interface IMerkleDropMinter is IMinterModule {
         address affiliate
     ) external payable;
 
-    /*
+    /**
      * @dev Sets the `price` for (`edition`, `mintId`).
      * @param edition Address of the song edition contract we are minting for.
      * @param mintId  The mint ID.
@@ -183,7 +183,7 @@ interface IMerkleDropMinter is IMinterModule {
         uint96 price
     ) external;
 
-    /*
+    /**
      * @dev Sets the `maxMintablePerAccount` for (`edition`, `mintId`).
      * @param edition               Address of the song edition contract we are minting for.
      * @param mintId                The mint ID.
@@ -195,7 +195,7 @@ interface IMerkleDropMinter is IMinterModule {
         uint32 maxMintablePerAccount
     ) external;
 
-    /*
+    /**
      * @dev Sets the `maxMintable` for (`edition`, `mintId`).
      * @param edition               Address of the song edition contract we are minting for.
      * @param mintId                The mint ID.
@@ -207,7 +207,7 @@ interface IMerkleDropMinter is IMinterModule {
         uint32 maxMintable
     ) external;
 
-    /*
+    /**
      * @dev Sets the `merkleRootHash` for (`edition`, `mintId`).
      * @param edition        Address of the song edition contract we are minting for.
      * @param mintId         The mint ID.

--- a/contracts/modules/interfaces/IRangeEditionMinter.sol
+++ b/contracts/modules/interfaces/IRangeEditionMinter.sol
@@ -131,7 +131,7 @@ interface IRangeEditionMinter is IMinterModule {
     //               PUBLIC / EXTERNAL WRITE FUNCTIONS
     // =============================================================
 
-    /*
+    /**
      * @dev Initializes a range mint instance
      * @param edition                Address of the song edition contract we are minting for.
      * @param price                  Sale price in ETH for minting a single token in `edition`.
@@ -158,7 +158,7 @@ interface IRangeEditionMinter is IMinterModule {
         uint32 maxMintablePerAccount_
     ) external returns (uint128 mintId);
 
-    /*
+    /**
      * @dev Sets the time range.
      * @param edition     Address of the song edition contract we are minting for.
      * @param startTime   Start timestamp of sale (in seconds since unix epoch).
@@ -175,7 +175,7 @@ interface IRangeEditionMinter is IMinterModule {
         uint32 endTime
     ) external;
 
-    /*
+    /**
      * @dev Sets the max mintable range.
      * @param edition          Address of the song edition contract we are minting for.
      * @param maxMintableLower The lower limit of the maximum number of tokens that can be minted.
@@ -188,7 +188,7 @@ interface IRangeEditionMinter is IMinterModule {
         uint32 maxMintableUpper
     ) external;
 
-    /*
+    /**
      * @dev Mints tokens for a given edition.
      * @param edition  Address of the song edition contract we are minting for.
      * @param quantity Token quantity to mint in song `edition`.
@@ -200,7 +200,7 @@ interface IRangeEditionMinter is IMinterModule {
         address affiliate
     ) external payable;
 
-    /*
+    /**
      * @dev Sets the `price` for (`edition`, `mintId`).
      * @param edition Address of the song edition contract we are minting for.
      * @param mintId  The mint ID.
@@ -212,7 +212,7 @@ interface IRangeEditionMinter is IMinterModule {
         uint96 price
     ) external;
 
-    /*
+    /**
      * @dev Sets the `maxMintablePerAccount` for (`edition`, `mintId`).
      * @param edition               Address of the song edition contract we are minting for.
      * @param mintId                The mint ID.


### PR DESCRIPTION
- Fix comment style for some Natspec. 
- Renamed `minter` to `to` for some functions for (clarity). 
