### PR TITLE
Add totalMinted to EditionMaxMinter MintInfo

### DIFF
--- a/contracts/modules/EditionMaxMinter.sol
+++ b/contracts/modules/EditionMaxMinter.sol
@@ -146,9 +146,11 @@ contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {
         info.affiliateFeeBPS = baseData.affiliateFeeBPS;
         info.mintPaused = baseData.mintPaused;
         info.price = mintData.price;
-        info.maxMintablePerAccount = mintData.maxMintablePerAccount;
+        
         info.maxMintableLower = editionInfo.editionMaxMintableLower;
         info.maxMintableUpper = editionInfo.editionMaxMintableUpper;
+        info.maxMintablePerAccount = mintData.maxMintablePerAccount;
+        info.totalMinted = uint32(editionInfo.totalMinted);
         info.cutoffTime = editionInfo.editionCutoffTime;
     }
 

--- a/contracts/modules/EditionMaxMinter.sol
+++ b/contracts/modules/EditionMaxMinter.sol
@@ -146,7 +146,7 @@ contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {
         info.affiliateFeeBPS = baseData.affiliateFeeBPS;
         info.mintPaused = baseData.mintPaused;
         info.price = mintData.price;
-        
+
         info.maxMintableLower = editionInfo.editionMaxMintableLower;
         info.maxMintableUpper = editionInfo.editionMaxMintableUpper;
         info.maxMintablePerAccount = mintData.maxMintablePerAccount;

--- a/contracts/modules/interfaces/IEditionMaxMinter.sol
+++ b/contracts/modules/interfaces/IEditionMaxMinter.sol
@@ -22,9 +22,10 @@ struct MintInfo {
     uint16 affiliateFeeBPS;
     bool mintPaused;
     uint96 price;
-    uint32 maxMintablePerAccount;
     uint32 maxMintableLower;
     uint32 maxMintableUpper;
+    uint32 maxMintablePerAccount;
+    uint32 totalMinted;
     uint32 cutoffTime;
 }
 

--- a/tests/modules/EditionMaxMinter.t.sol
+++ b/tests/modules/EditionMaxMinter.t.sol
@@ -383,9 +383,11 @@ contract EditionMaxMinterTests is TestConfig {
         assertEq(affiliateFeeBPS, mintInfo.affiliateFeeBPS);
         assertEq(false, mintInfo.mintPaused);
         assertEq(price, mintInfo.price);
-        assertEq(maxMintablePerAccount, mintInfo.maxMintablePerAccount);
+        
         assertEq(editionMaxMintableLower, mintInfo.maxMintableLower);
         assertEq(editionMaxMintableUpper, mintInfo.maxMintableUpper);
+        assertEq(maxMintablePerAccount, mintInfo.maxMintablePerAccount);
+        assertEq(0, mintInfo.totalMinted);
         assertEq(editionCutOffTime, mintInfo.cutoffTime);
 
         assertEq(0, edition.totalMinted());
@@ -403,6 +405,7 @@ contract EditionMaxMinterTests is TestConfig {
         mintInfo = minter.mintInfo(address(edition), MINT_ID);
 
         assertEq(quantity, edition.totalMinted());
+        assertEq(quantity, mintInfo.totalMinted);
     }
 
     function test_mintInfo() public {

--- a/tests/modules/EditionMaxMinter.t.sol
+++ b/tests/modules/EditionMaxMinter.t.sol
@@ -383,7 +383,7 @@ contract EditionMaxMinterTests is TestConfig {
         assertEq(affiliateFeeBPS, mintInfo.affiliateFeeBPS);
         assertEq(false, mintInfo.mintPaused);
         assertEq(price, mintInfo.price);
-        
+
         assertEq(editionMaxMintableLower, mintInfo.maxMintableLower);
         assertEq(editionMaxMintableUpper, mintInfo.maxMintableUpper);
         assertEq(maxMintablePerAccount, mintInfo.maxMintablePerAccount);


### PR DESCRIPTION
For consistency with RangeEditionMinter, and hopefully reduce number of RPC calls.