### PR TITLE
Refactor minters to take in `to` argument instead of using `msg.sender`

### DIFF
--- a/contracts/modules/EditionMaxMinter.sol
+++ b/contracts/modules/EditionMaxMinter.sol
@@ -72,6 +72,7 @@ contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         address affiliate
     ) public payable {
@@ -79,13 +80,13 @@ contract EditionMaxMinter is IEditionMaxMinter, BaseMinter {
 
         unchecked {
             // Check the additional `requestedQuantity` does not exceed the maximum mintable per account.
-            uint256 numberMinted = ISoundEditionV1(edition).numberMinted(msg.sender);
+            uint256 numberMinted = ISoundEditionV1(edition).numberMinted(to);
             // Won't overflow. The total number of tokens minted in `edition` won't exceed `type(uint32).max`,
             // and `quantity` has 32 bits.
             if (numberMinted + quantity > data.maxMintablePerAccount) revert ExceedsMaxPerAccount();
         }
 
-        _mint(edition, mintId, quantity, affiliate);
+        _mint(edition, mintId, to, quantity, affiliate);
     }
 
     /**

--- a/contracts/modules/FixedPriceSignatureMinter.sol
+++ b/contracts/modules/FixedPriceSignatureMinter.sol
@@ -94,6 +94,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         uint32 signedQuantity,
         address affiliate,
@@ -111,9 +112,9 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
 
         data.totalMinted = _incrementTotalMinted(data.totalMinted, quantity, data.maxMintable);
 
-        _validateSignatureAndClaim(signature, data.signer, claimTicket, edition, mintId, signedQuantity, affiliate);
+        _validateSignatureAndClaim(signature, data.signer, claimTicket, edition, mintId, to, signedQuantity, affiliate);
 
-        _mint(edition, mintId, quantity, affiliate);
+        _mint(edition, mintId, to, quantity, affiliate);
     }
 
     /**
@@ -246,6 +247,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
      * @param claimTicket    The ticket number to enforce single-use of the signature.
      * @param edition        The edition address.
      * @param mintId         The mint instance ID.
+     * @param to             The address to mint to.
      * @param signedQuantity The max quantity this buyer has been approved to mint.
      * @param affiliate      The affiliate address.
      */
@@ -255,6 +257,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
         uint32 claimTicket,
         address edition,
         uint128 mintId,
+        address to,
         uint32 signedQuantity,
         address affiliate
     ) private {
@@ -262,7 +265,7 @@ contract FixedPriceSignatureMinter is IFixedPriceSignatureMinter, BaseMinter {
             abi.encodePacked(
                 "\x19\x01",
                 DOMAIN_SEPARATOR(),
-                keccak256(abi.encode(MINT_TYPEHASH, msg.sender, mintId, claimTicket, signedQuantity, affiliate))
+                keccak256(abi.encode(MINT_TYPEHASH, to, mintId, claimTicket, signedQuantity, affiliate))
             )
         );
 

--- a/contracts/modules/RangeEditionMinter.sol
+++ b/contracts/modules/RangeEditionMinter.sol
@@ -82,6 +82,7 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         address affiliate
     ) public payable {
@@ -95,13 +96,13 @@ contract RangeEditionMinter is IRangeEditionMinter, BaseMinter {
 
         unchecked {
             // Check the additional `requestedQuantity` does not exceed the maximum mintable per account.
-            uint256 numberMinted = ISoundEditionV1(edition).numberMinted(msg.sender);
+            uint256 numberMinted = ISoundEditionV1(edition).numberMinted(to);
             // Won't overflow. The total number of tokens minted in `edition` won't exceed `type(uint32).max`,
             // and `quantity` has 32 bits.
             if (numberMinted + quantity > data.maxMintablePerAccount) revert ExceedsMaxPerAccount();
         }
 
-        _mint(edition, mintId, quantity, affiliate);
+        _mint(edition, mintId, to, quantity, affiliate);
     }
 
     /**

--- a/contracts/modules/interfaces/IEditionMaxMinter.sol
+++ b/contracts/modules/interfaces/IEditionMaxMinter.sol
@@ -116,12 +116,14 @@ interface IEditionMaxMinter is IMinterModule {
      * @dev Mints tokens for a given edition.
      * @param edition   Address of the song edition contract we are minting for.
      * @param mintId    The mint ID.
+     * @param to        The address to mint to.
      * @param quantity  Token quantity to mint in song `edition`.
      * @param affiliate The affiliate address.
      */
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         address affiliate
     ) external payable;

--- a/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
+++ b/contracts/modules/interfaces/IFixedPriceSignatureMinter.sol
@@ -138,7 +138,9 @@ interface IFixedPriceSignatureMinter is IMinterModule {
 
     /**
      * @dev Mints a token for a particular mint instance.
+     * @param edition        Address of the song edition contract we are minting for.
      * @param mintId         The mint ID.
+     * @param to             The address to mint to.
      * @param quantity       The quantity of tokens to mint.
      * @param signedQuantity The max quantity this buyer has been approved to mint.
      * @param affiliate      The affiliate address.
@@ -148,6 +150,7 @@ interface IFixedPriceSignatureMinter is IMinterModule {
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         uint32 signedQuantity,
         address affiliate,

--- a/contracts/modules/interfaces/IMerkleDropMinter.sol
+++ b/contracts/modules/interfaces/IMerkleDropMinter.sol
@@ -160,14 +160,19 @@ interface IMerkleDropMinter is IMinterModule {
 
     /**
      * @dev Mints a token for a particular mint instance.
-     * @param mintId            The ID of the mint instance.
-     * @param requestedQuantity The quantity of tokens to mint.
+     * @param edition  Address of the song edition contract we are minting for.
+     * @param mintId   The mint ID.
+     * @param to       The address to mint to.
+     * @param quantity The quantity of tokens to mint.
+     * @param proof    The merkle proof.
+     * @param affiliate The affiliate address.
      */
     function mint(
         address edition,
         uint128 mintId,
-        uint32 requestedQuantity,
-        bytes32[] calldata merkleProof,
+        address to,
+        uint32 quantity,
+        bytes32[] calldata proof,
         address affiliate
     ) external payable;
 

--- a/contracts/modules/interfaces/IRangeEditionMinter.sol
+++ b/contracts/modules/interfaces/IRangeEditionMinter.sol
@@ -190,12 +190,16 @@ interface IRangeEditionMinter is IMinterModule {
 
     /**
      * @dev Mints tokens for a given edition.
-     * @param edition  Address of the song edition contract we are minting for.
-     * @param quantity Token quantity to mint in song `edition`.
+     * @param edition   Address of the song edition contract we are minting for.
+     * @param mintId    The mint ID.
+     * @param to        The address to mint to.
+     * @param quantity  Token quantity to mint in song `edition`.
+     * @param affiliate The affiliate address.
      */
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         address affiliate
     ) external payable;

--- a/tests/mocks/MockMinter.sol
+++ b/tests/mocks/MockMinter.sol
@@ -28,10 +28,11 @@ contract MockMinter is BaseMinter {
     function mint(
         address edition,
         uint128 mintId,
+        address to,
         uint32 quantity,
         address affiliate
     ) external payable {
-        _mint(edition, mintId, quantity, affiliate);
+        _mint(edition, mintId, to, quantity, affiliate);
     }
 
     function setPrice(uint96 price) external {

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -229,6 +229,28 @@ contract MintControllerBaseTests is TestConfig {
         }
     }
 
+    function test_mintToDifferentAddress() external {
+        minter.setPrice(0);
+
+        SoundEditionV1 edition = _createEdition(EDITION_MAX_MINTABLE);
+
+        uint128 mintId = minter.createEditionMint(address(edition), START_TIME, END_TIME, AFFILIATE_FEE_BPS);
+
+        unchecked {
+            uint256 seed = uint256(keccak256(bytes("test_mintToDifferentAddress()")));
+            for (uint256 i; i < 10; ++i) {
+                address to = getFundedAccount(uint256(keccak256(abi.encode(i + seed))));
+                uint256 quantity;
+                for (uint256 j = 1e9; quantity == 0; ++j) {
+                    quantity = uint256(keccak256(abi.encode(j + i + seed))) % 10;
+                }
+                assertEq(edition.balanceOf(to), 0);
+                minter.mint(address(edition), mintId, to, uint32(quantity), address(0));
+                assertEq(edition.balanceOf(to), quantity);
+            }
+        }
+    }
+
     function test_cantMintPastEditionMaxMintable() external {
         minter.setPrice(0);
 

--- a/tests/modules/BaseMinter.t.sol
+++ b/tests/modules/BaseMinter.t.sol
@@ -140,9 +140,9 @@ contract MintControllerBaseTests is TestConfig {
         minter.setPrice(price);
 
         vm.expectRevert(abi.encodeWithSelector(IMinterModule.Underpaid.selector, price * 2 - 1, price * 2));
-        minter.mint{ value: price * 2 - 1 }(address(edition), mintId, 2, address(0));
+        minter.mint{ value: price * 2 - 1 }(address(edition), mintId, address(this), 2, address(0));
 
-        minter.mint{ value: price * 2 }(address(edition), mintId, 2, address(0));
+        minter.mint{ value: price * 2 }(address(edition), mintId, address(this), 2, address(0));
     }
 
     function test_mintRefundsForOverpaid() public {
@@ -160,7 +160,7 @@ contract MintControllerBaseTests is TestConfig {
         uint256 balanceBefore = buyer.balance;
 
         vm.prank(buyer);
-        minter.mint{ value: price * (quantity + 1) }(address(edition), mintId, quantity, address(0));
+        minter.mint{ value: price * (quantity + 1) }(address(edition), mintId, buyer, quantity, address(0));
 
         uint256 balanceAfter = buyer.balance;
 
@@ -182,7 +182,7 @@ contract MintControllerBaseTests is TestConfig {
         uint256 balanceBefore = buyer.balance;
 
         vm.prank(buyer);
-        minter.mint{ value: price * quantity }(address(edition), mintId, quantity, address(0));
+        minter.mint{ value: price * quantity }(address(edition), mintId, buyer, quantity, address(0));
 
         uint256 balanceAfter = buyer.balance;
 
@@ -201,11 +201,11 @@ contract MintControllerBaseTests is TestConfig {
 
         vm.expectRevert(IMinterModule.MintPaused.selector);
 
-        minter.mint{ value: price * 2 }(address(edition), mintId, 2, address(0));
+        minter.mint{ value: price * 2 }(address(edition), mintId, address(this), 2, address(0));
 
         minter.setEditionMintPaused(address(edition), mintId, false);
 
-        minter.mint{ value: price * 2 }(address(edition), mintId, 2, address(0));
+        minter.mint{ value: price * 2 }(address(edition), mintId, address(this), 2, address(0));
     }
 
     function test_mintRevertsWithZeroQuantity() public {
@@ -217,7 +217,7 @@ contract MintControllerBaseTests is TestConfig {
 
         vm.expectRevert(IERC721AUpgradeable.MintZeroQuantity.selector);
 
-        minter.mint{ value: 0 }(address(edition), mintId, 0, address(0));
+        minter.mint{ value: 0 }(address(edition), mintId, address(this), 0, address(0));
     }
 
     function test_createEditionMintMultipleTimes() external {
@@ -238,14 +238,14 @@ contract MintControllerBaseTests is TestConfig {
         uint128 mintId1 = minter.createEditionMint(address(edition1), START_TIME, END_TIME, AFFILIATE_FEE_BPS);
 
         // Mint all of the supply except for 1 token
-        minter.mint(address(edition1), mintId1, maxSupply - 1, address(0));
+        minter.mint(address(edition1), mintId1, address(this), maxSupply - 1, address(0));
 
         // try minting 2 more - should fail and tell us there is only 1 available
         vm.expectRevert(abi.encodeWithSelector(ISoundEditionV1.ExceedsEditionAvailableSupply.selector, 1));
-        minter.mint(address(edition1), mintId1, 2, address(0));
+        minter.mint(address(edition1), mintId1, address(this), 2, address(0));
 
         // try minting 1 more - should succeed
-        minter.mint(address(edition1), mintId1, 1, address(0));
+        minter.mint(address(edition1), mintId1, address(this), 1, address(0));
     }
 
     function test_setTimeRange(address nonController) public {
@@ -347,7 +347,7 @@ contract MintControllerBaseTests is TestConfig {
 
         address affiliate = getFundedAccount(123456789);
 
-        minter.mint{ value: requiredEtherValue }(address(edition), mintId, quantity, affiliate);
+        minter.mint{ value: requiredEtherValue }(address(edition), mintId, address(this), quantity, affiliate);
 
         uint256 expectedAffiliateFees = (requiredEtherValue * affiliateFeeBPS) / minter.MAX_BPS();
 
@@ -374,7 +374,7 @@ contract MintControllerBaseTests is TestConfig {
 
         address affiliate = getFundedAccount(123456789);
 
-        minter.mint{ value: requiredEtherValue }(address(edition), mintId, quantity, affiliate);
+        minter.mint{ value: requiredEtherValue }(address(edition), mintId, address(this), quantity, affiliate);
 
         uint256 expectedPlatformFees = (requiredEtherValue * platformFeeBPS) / minter.MAX_BPS();
 
@@ -444,7 +444,7 @@ contract MintControllerBaseTests is TestConfig {
 
         vm.deal(buyer, requiredEtherValue);
         vm.prank(buyer);
-        minter.mint{ value: requiredEtherValue }(address(edition), mintId, quantity, affiliate);
+        minter.mint{ value: requiredEtherValue }(address(edition), mintId, buyer, quantity, affiliate);
 
         _test_withdrawAffiliateFeesAccrued(affiliate, expectedAffiliateFees);
         _test_withdrawPlatformFeesAccrued(expectedPlatformFees);

--- a/tests/modules/EditionMaxMinter.t.sol
+++ b/tests/modules/EditionMaxMinter.t.sol
@@ -173,7 +173,7 @@ contract EditionMaxMinterTests is TestConfig {
         address caller = getFundedAccount(1);
         vm.prank(caller);
         vm.expectRevert(IEditionMaxMinter.ExceedsMaxPerAccount.selector);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, address(this), 2, address(0));
     }
 
     function test_mintWhenOverMaxMintableDueToPreviousMintedReverts() public {
@@ -191,7 +191,7 @@ contract EditionMaxMinterTests is TestConfig {
         // attempting to mint 2 more reverts
         vm.prank(caller);
         vm.expectRevert(IEditionMaxMinter.ExceedsMaxPerAccount.selector);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, caller, 2, address(0));
     }
 
     function test_mintWhenMintablePerAccountIsSetAndSatisfied() public {
@@ -209,7 +209,7 @@ contract EditionMaxMinterTests is TestConfig {
         // Ensure we can mint the max allowed of 2 tokens
         vm.warp(START_TIME);
         vm.prank(caller);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, caller, 2, address(0));
 
         assertEq(edition.balanceOf(caller), 3);
 
@@ -228,7 +228,7 @@ contract EditionMaxMinterTests is TestConfig {
         assertEq(edition.totalMinted(), 0);
 
         vm.prank(caller);
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, caller, quantity, address(0));
 
         assertEq(edition.balanceOf(caller), uint256(quantity));
 
@@ -250,7 +250,7 @@ contract EditionMaxMinterTests is TestConfig {
         );
 
         vm.expectRevert(expectedRevert);
-        minter.mint{ value: requiredPayment - 1 }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: requiredPayment - 1 }(address(edition), MINT_ID, address(this), quantity, address(0));
     }
 
     function test_mintRevertsForMintNotOpen() public {
@@ -262,22 +262,22 @@ contract EditionMaxMinterTests is TestConfig {
         vm.expectRevert(
             abi.encodeWithSelector(IMinterModule.MintNotOpen.selector, block.timestamp, START_TIME, END_TIME)
         );
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(START_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(CUTOFF_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(END_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(END_TIME + 1);
         vm.expectRevert(
             abi.encodeWithSelector(IMinterModule.MintNotOpen.selector, block.timestamp, START_TIME, END_TIME)
         );
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
     }
 
     function test_setPrice(uint96 price) public {
@@ -398,6 +398,7 @@ contract EditionMaxMinterTests is TestConfig {
         minter.mint{ value: uint256(mintInfo.price) * uint256(quantity) }(
             address(edition),
             MINT_ID,
+            address(this),
             quantity,
             address(0)
         );

--- a/tests/modules/EditionMaxMinter.t.sol
+++ b/tests/modules/EditionMaxMinter.t.sol
@@ -166,6 +166,41 @@ contract EditionMaxMinterTests is TestConfig {
         minter.createEditionMint(address(edition), PRICE, START_TIME, END_TIME, AFFILIATE_FEE_BPS, type(uint32).max);
     }
 
+    function test_mintToDifferentAddress() external {
+        SoundEditionV1 edition = createGenericEdition();
+
+        edition.setEditionMaxMintableRange(0, EDITION_MAX_MINTABLE);
+        edition.setEditionCutoffTime(CUTOFF_TIME);
+
+        EditionMaxMinter minter = new EditionMaxMinter(feeRegistry);
+
+        edition.grantRoles(address(minter), edition.MINTER_ROLE());
+
+        minter.createEditionMint(
+            address(edition),
+            PRICE,
+            START_TIME,
+            END_TIME,
+            AFFILIATE_FEE_BPS,
+            EDITION_MAX_MINTABLE
+        );
+
+        vm.warp(START_TIME);
+        unchecked {
+            uint256 seed = uint256(keccak256(bytes("test_mintToDifferentAddress()")));
+            for (uint256 i; i < 10; ++i) {
+                address to = getFundedAccount(uint256(keccak256(abi.encode(i + seed))));
+                uint256 quantity;
+                for (uint256 j = 1e9; quantity == 0; ++j) {
+                    quantity = uint256(keccak256(abi.encode(j + i + seed))) % 10;
+                }
+                assertEq(edition.balanceOf(to), 0);
+                minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, to, uint32(quantity), address(0));
+                assertEq(edition.balanceOf(to), quantity);
+            }
+        }
+    }
+
     function test_mintWhenOverMaxMintablePerAccountReverts() public {
         (SoundEditionV1 edition, EditionMaxMinter minter) = _createEditionAndMinter(1);
         vm.warp(START_TIME);

--- a/tests/modules/FixedPriceSignatureMinter.t.sol
+++ b/tests/modules/FixedPriceSignatureMinter.t.sol
@@ -190,6 +190,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -214,6 +215,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -243,6 +245,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity - 1 }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -266,6 +269,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * (MAX_MINTABLE + 1) }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -281,6 +285,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * MAX_MINTABLE }(
             address(edition),
             MINT_ID,
+            buyer,
             MAX_MINTABLE,
             MAX_MINTABLE,
             NULL_AFFILIATE,
@@ -296,6 +301,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -323,6 +329,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -338,6 +345,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -373,6 +381,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             nonExistentMintId,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -405,6 +414,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -441,6 +451,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -463,6 +474,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -522,6 +534,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition1),
             mintId1,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -536,6 +549,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition2),
             mintId2,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -586,6 +600,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             mintId1,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -600,6 +615,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             mintId2,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -649,6 +665,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
             minter.mint{ value: PRICE }(
                 address(edition),
                 mintId,
+                buyer,
                 QUANTITY_1,
                 SIGNED_QUANTITY_1,
                 NULL_AFFILIATE,
@@ -795,6 +812,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -808,6 +826,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -840,6 +859,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -854,6 +874,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * quantity }(
             address(edition),
             MINT_ID,
+            buyer,
             quantity,
             signedQuantity,
             NULL_AFFILIATE,
@@ -876,6 +897,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * QUANTITY_1 }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             wrongAffiliate,
@@ -889,6 +911,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * QUANTITY_1 }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             NULL_AFFILIATE,
@@ -901,6 +924,7 @@ contract FixedPriceSignatureMinterTests is TestConfig {
         minter.mint{ value: PRICE * QUANTITY_1 }(
             address(edition),
             MINT_ID,
+            buyer,
             QUANTITY_1,
             SIGNED_QUANTITY_1,
             affiliate,

--- a/tests/modules/GoldenEggMetadata.t.sol
+++ b/tests/modules/GoldenEggMetadata.t.sol
@@ -105,7 +105,7 @@ contract GoldenEggMetadataTests is TestConfig {
             EDITION_MAX_MINTABLE // max mintable per account
         );
 
-        minter.mint{ value: PRICE * mintQuantity }(address(edition), MINT_ID, mintQuantity, address(0));
+        minter.mint{ value: PRICE * mintQuantity }(address(edition), MINT_ID, address(this), mintQuantity, address(0));
 
         vm.warp(editionCutoffTime);
 
@@ -128,7 +128,7 @@ contract GoldenEggMetadataTests is TestConfig {
             CUTOFF_TIME
         );
 
-        minter.mint{ value: PRICE }(address(edition), MINT_ID, 1, address(0));
+        minter.mint{ value: PRICE }(address(edition), MINT_ID, address(this), 1, address(0));
         uint256 tokenId = 1;
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
@@ -146,7 +146,7 @@ contract GoldenEggMetadataTests is TestConfig {
 
         uint32 quantity = MAX_MINTABLE_UPPER;
 
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         string memory expectedTokenURI = string.concat(BASE_URI, "goldenEgg");
@@ -161,14 +161,14 @@ contract GoldenEggMetadataTests is TestConfig {
             CUTOFF_TIME
         );
 
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         // check golden egg has not been generated after minting one less than the max
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         assertEq(goldenEggTokenId, 0);
 
         // Mint one more to bring us to maxMintableLower
-        minter.mint{ value: PRICE }(address(edition), MINT_ID, 1, address(0));
+        minter.mint{ value: PRICE }(address(edition), MINT_ID, address(this), 1, address(0));
 
         // Warp to cutoff time, which is set to randomnessLockedTimeThreshold
         vm.warp(CUTOFF_TIME);
@@ -187,7 +187,7 @@ contract GoldenEggMetadataTests is TestConfig {
         (SoundEditionV1 edition, RangeEditionMinter minter, ) = _createEdition(CUTOFF_TIME);
 
         uint32 quantity = MAX_MINTABLE_LOWER - 1;
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         address caller = getFundedAccount(1);
         vm.prank(caller);
@@ -202,7 +202,7 @@ contract GoldenEggMetadataTests is TestConfig {
         );
 
         uint32 quantity = MAX_MINTABLE_LOWER - 1;
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         // golden egg not generated
@@ -227,7 +227,7 @@ contract GoldenEggMetadataTests is TestConfig {
         edition.grantRoles(admin, edition.ADMIN_ROLE());
 
         uint32 quantity = MAX_MINTABLE_LOWER - 1;
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         // golden egg not generated
@@ -266,7 +266,7 @@ contract GoldenEggMetadataTests is TestConfig {
         );
 
         uint32 quantity = MAX_MINTABLE_LOWER;
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         // golden egg not generated
@@ -293,7 +293,7 @@ contract GoldenEggMetadataTests is TestConfig {
         edition.grantRoles(admin, edition.ADMIN_ROLE());
 
         uint32 quantity = MAX_MINTABLE_LOWER;
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         uint256 goldenEggTokenId = goldenEggModule.getGoldenEggTokenId(edition);
         // golden egg not generated

--- a/tests/modules/MerkleDropMinter.t.sol
+++ b/tests/modules/MerkleDropMinter.t.sol
@@ -114,13 +114,13 @@ contract MerkleDropMinterTests is TestConfig {
 
         uint32 requestedQuantity = 1;
         vm.prank(accounts[1]);
-        minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
+        minter.mint(address(edition), mintId, accounts[1], requestedQuantity, proof, address(0));
         user1Balance = edition.balanceOf(accounts[1]);
         assertEq(user1Balance, 1);
 
         // Claim the second of the 2 max per account
         vm.prank(accounts[1]);
-        minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
+        minter.mint(address(edition), mintId, accounts[1], requestedQuantity, proof, address(0));
         user1Balance = edition.balanceOf(accounts[1]);
         assertEq(user1Balance, 2);
     }
@@ -139,7 +139,7 @@ contract MerkleDropMinterTests is TestConfig {
         vm.prank(accounts[0]);
         vm.expectRevert(IMerkleDropMinter.ExceedsMaxPerAccount.selector);
         // Max is 1 but buyer is requesting 2
-        minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
+        minter.mint(address(edition), mintId, accounts[0], requestedQuantity, proof, address(0));
     }
 
     function test_cannotClaimMoreThanMaxMintable() public {
@@ -156,7 +156,7 @@ contract MerkleDropMinterTests is TestConfig {
         vm.warp(START_TIME);
         vm.prank(accounts[2]);
         vm.expectRevert(abi.encodeWithSelector(IMinterModule.ExceedsAvailableSupply.selector, 2));
-        minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
+        minter.mint(address(edition), mintId, address(this), requestedQuantity, proof, address(0));
     }
 
     function test_cannotClaimWithInvalidProof() public {
@@ -167,7 +167,7 @@ contract MerkleDropMinterTests is TestConfig {
         vm.prank(accounts[0]);
         uint32 requestedQuantity = 1;
         vm.expectRevert(IMerkleDropMinter.InvalidMerkleProof.selector);
-        minter.mint(address(edition), mintId, requestedQuantity, proof, address(0));
+        minter.mint(address(edition), mintId, address(this), requestedQuantity, proof, address(0));
     }
 
     function test_setPrice(uint96 price) public {

--- a/tests/modules/MerkleDropMinter.t.sol
+++ b/tests/modules/MerkleDropMinter.t.sol
@@ -98,6 +98,30 @@ contract MerkleDropMinterTests is TestConfig {
         );
     }
 
+    function test_mintToDifferentAddress() external {
+        (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(
+            0,
+            EDITION_MAX_MINTABLE,
+            EDITION_MAX_MINTABLE
+        );
+
+        vm.warp(START_TIME);
+        unchecked {
+            uint256 seed = uint256(keccak256(bytes("test_mintToDifferentAddress()")));
+            for (uint256 i; i < accounts.length; ++i) {
+                address to = accounts[i];
+                bytes32[] memory proof = m.getProof(leaves, i);
+                uint256 quantity;
+                for (uint256 j = 1e9; quantity == 0; ++j) {
+                    quantity = uint256(keccak256(abi.encode(j + i + seed))) % 10;
+                }
+                assertEq(edition.balanceOf(to), 0);
+                minter.mint(address(edition), mintId, to, uint32(quantity), proof, address(0));
+                assertEq(edition.balanceOf(to), quantity);
+            }
+        }
+    }
+
     function test_canMintMultipleTimesLessThanMaxMintablePerAccount() public {
         uint32 maxPerAccount = 2;
         (SoundEditionV1 edition, MerkleDropMinter minter, uint128 mintId) = _createEditionAndMinter(

--- a/tests/modules/MintersIntegration.t.sol
+++ b/tests/modules/MintersIntegration.t.sol
@@ -168,7 +168,7 @@ contract MintersIntegration is TestConfig {
         // Claim 1 token
         bytes32[] memory proof0 = merkleFreeDrop.getProof(leavesFreeMerkleDrop, 0);
         vm.prank(accountsFreeMerkleDrop[0]);
-        merkleDropMinter.mint(address(edition), mintId, 1, proof0, address(0));
+        merkleDropMinter.mint(address(edition), mintId, accountsFreeMerkleDrop[0], 1, proof0, address(0));
         user0Balance = edition.balanceOf(accountsFreeMerkleDrop[0]);
         assertEq(user0Balance, 1);
 
@@ -178,13 +178,13 @@ contract MintersIntegration is TestConfig {
         assertEq(user1Balance, 0);
         // Claim 3 tokens (max per account)
         vm.prank(accountsFreeMerkleDrop[1]);
-        merkleDropMinter.mint(address(edition), mintId, 3, proof1, address(0));
+        merkleDropMinter.mint(address(edition), mintId, accountsFreeMerkleDrop[1], 3, proof1, address(0));
         user1Balance = edition.balanceOf(accountsFreeMerkleDrop[1]);
         assertEq(user1Balance, 3);
 
         // First user comes back to claim 2 more tokens, bringing balance to 3 (max per account)
         vm.prank(accountsFreeMerkleDrop[0]);
-        merkleDropMinter.mint(address(edition), mintId, 2, proof0, address(0));
+        merkleDropMinter.mint(address(edition), mintId, accountsFreeMerkleDrop[0], 2, proof0, address(0));
         user0Balance = edition.balanceOf(accountsFreeMerkleDrop[0]);
         assertEq(user0Balance, 3);
 
@@ -205,7 +205,14 @@ contract MintersIntegration is TestConfig {
         // Claim 20 tokens
         bytes32[] memory proof0 = mPresale.getProof(leavesPresale, 0);
         vm.prank(accountsPresale[0]);
-        merkleDropMinter.mint{ value: 20 * PRICE_PRESALE }(address(edition), mintId, 20, proof0, address(0));
+        merkleDropMinter.mint{ value: 20 * PRICE_PRESALE }(
+            address(edition),
+            mintId,
+            accountsPresale[0],
+            20,
+            proof0,
+            address(0)
+        );
         user0Balance = edition.balanceOf(accountsPresale[0]);
         assertEq(user0Balance, 20);
 
@@ -215,7 +222,14 @@ contract MintersIntegration is TestConfig {
         assertEq(user1Balance, 0);
         // Claim 25 tokens
         vm.prank(accountsPresale[1]);
-        merkleDropMinter.mint{ value: 25 * PRICE_PRESALE }(address(edition), mintId, 25, proof1, address(0));
+        merkleDropMinter.mint{ value: 25 * PRICE_PRESALE }(
+            address(edition),
+            mintId,
+            accountsPresale[1],
+            25,
+            proof1,
+            address(0)
+        );
         user1Balance = edition.balanceOf(accountsPresale[1]);
         assertEq(user1Balance, 25);
 
@@ -229,7 +243,7 @@ contract MintersIntegration is TestConfig {
         assertEq(user5Balance, 0);
         // Mint 5 tokens
         vm.prank(userAccounts[4]);
-        publicSaleMinter.mint{ value: 5 * PRICE_PUBLIC_SALE }(address(edition), mintId, 5, address(0));
+        publicSaleMinter.mint{ value: 5 * PRICE_PUBLIC_SALE }(address(edition), mintId, userAccounts[4], 5, address(0));
         user5Balance = edition.balanceOf(userAccounts[4]);
         assertEq(user5Balance, 5);
 
@@ -241,6 +255,7 @@ contract MintersIntegration is TestConfig {
         publicSaleMinter.mint{ value: MAX_MINTABLE_PER_ACCOUNT_PUBLIC_SALE * PRICE_PUBLIC_SALE }(
             address(edition),
             mintId,
+            userAccounts[5],
             MAX_MINTABLE_PER_ACCOUNT_PUBLIC_SALE,
             address(0)
         );

--- a/tests/modules/RangeEditionMinter.t.sol
+++ b/tests/modules/RangeEditionMinter.t.sol
@@ -227,7 +227,7 @@ contract RangeEditionMinterTests is TestConfig {
         address caller = getFundedAccount(1);
         vm.prank(caller);
         vm.expectRevert(IRangeEditionMinter.ExceedsMaxPerAccount.selector);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, address(this), 2, address(0));
     }
 
     function test_mintWhenOverMaxMintableDueToPreviousMintedReverts() public {
@@ -245,7 +245,7 @@ contract RangeEditionMinterTests is TestConfig {
         // attempting to mint 2 more reverts
         vm.prank(caller);
         vm.expectRevert(IRangeEditionMinter.ExceedsMaxPerAccount.selector);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, caller, 2, address(0));
     }
 
     function test_mintWhenMintablePerAccountIsSetAndSatisfied() public {
@@ -263,7 +263,7 @@ contract RangeEditionMinterTests is TestConfig {
         // Ensure we can mint the max allowed of 2 tokens
         vm.warp(START_TIME);
         vm.prank(caller);
-        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, 2, address(0));
+        minter.mint{ value: PRICE * 2 }(address(edition), MINT_ID, caller, 2, address(0));
 
         assertEq(edition.balanceOf(caller), 3);
 
@@ -284,7 +284,7 @@ contract RangeEditionMinterTests is TestConfig {
         assertEq(data.totalMinted, 0);
 
         vm.prank(caller);
-        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: PRICE * quantity }(address(edition), MINT_ID, caller, quantity, address(0));
 
         assertEq(edition.balanceOf(caller), uint256(quantity));
 
@@ -308,7 +308,7 @@ contract RangeEditionMinterTests is TestConfig {
         );
 
         vm.expectRevert(expectedRevert);
-        minter.mint{ value: requiredPayment - 1 }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: requiredPayment - 1 }(address(edition), MINT_ID, address(this), quantity, address(0));
     }
 
     function test_mintRevertsForMintNotOpen() public {
@@ -320,22 +320,22 @@ contract RangeEditionMinterTests is TestConfig {
         vm.expectRevert(
             abi.encodeWithSelector(IMinterModule.MintNotOpen.selector, block.timestamp, START_TIME, END_TIME)
         );
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(START_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(END_TIME + 1);
         vm.expectRevert(
             abi.encodeWithSelector(IMinterModule.MintNotOpen.selector, block.timestamp, START_TIME, END_TIME)
         );
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(END_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(CUTOFF_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
     }
 
     function test_mintRevertsForSoldOut(uint32 quantityToBuyBeforeCutoff, uint32 quantityToBuyAfterCutoff) public {
@@ -357,6 +357,7 @@ contract RangeEditionMinterTests is TestConfig {
         minter.mint{ value: quantityToBuyBeforeCutoff * PRICE }(
             address(edition),
             MINT_ID,
+            address(this),
             quantityToBuyBeforeCutoff,
             address(0)
         );
@@ -369,6 +370,7 @@ contract RangeEditionMinterTests is TestConfig {
         minter.mint{ value: quantityToBuyAfterCutoff * PRICE }(
             address(edition),
             MINT_ID,
+            address(this),
             quantityToBuyAfterCutoff,
             address(0)
         );
@@ -388,11 +390,11 @@ contract RangeEditionMinterTests is TestConfig {
         minter.setMaxMintableRange(address(edition), MINT_ID, maxMintableLower, maxMintableUpper);
 
         vm.warp(START_TIME);
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
 
         vm.warp(CUTOFF_TIME);
         vm.expectRevert(abi.encodeWithSelector(IMinterModule.ExceedsAvailableSupply.selector, maxMintableLower));
-        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, quantity, address(0));
+        minter.mint{ value: quantity * PRICE }(address(edition), MINT_ID, address(this), quantity, address(0));
     }
 
     function test_canSetTimeRangeBaseMinter(address nonController) public {
@@ -586,7 +588,7 @@ contract RangeEditionMinterTests is TestConfig {
 
         // Warp to start time & mint some tokens to test that totalMinted changed
         vm.warp(expectedStartTime);
-        minter.mint{ value: mintData.price * 4 }(address(edition), MINT_ID, 4, address(0));
+        minter.mint{ value: mintData.price * 4 }(address(edition), MINT_ID, address(this), 4, address(0));
 
         mintData = minter.mintInfo(address(edition), MINT_ID);
 


### PR DESCRIPTION
Currently, minters mint to the `msg.sender`.

Unfortunately, this blocks the use case of using warm wallets to mint to cold wallets.

This may make it easier for simple bots, but currently, we already have seen sophisticated bots that disseminate ETH to many separate accounts. So, we may as well add this since it allows for more functionality for users.

Instead, we change all minters to take in a `to` argument, which is the address of the wallet to mint to.

For MerkleDropMinter, any wallet can do the claim + payment (if any) to an address that is in the merkle tree.
So, if a warm wallet that is delegated by a cold wallet is detected, 
the `to` address should be replaced with the cold wallet's address, 
and the proof should be for minting to the cold wallet's address.